### PR TITLE
Refactor to provide some modularization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: true
 node_js:
-- "4.2.3"
+- "6.6.0"
 env:
   global:
   - CF_API=https://api.cloud.gov

--- a/app.js
+++ b/app.js
@@ -13,26 +13,12 @@ var queueUrl = process.env.SQS_URL,
     debugMode = process.env.DEBUG || false;
 
 // Librarys
-var AWS = require('aws-sdk'),
-    http = require('http'),
-    cfenv = require('cfenv'),
-    appEnv = cfenv.getAppEnv(),
-    awsCreds = appEnv.getServiceCreds('federalist-aws-user');
-
-// If running in Cloud Foundry, use AWS credentials from a service
-if (awsCreds) {
-  log('AWS Creds received: ', Object.keys(awsCreds));
-
-  AWS.config.update({
-    accessKeyId: awsCreds.access_key,
-    secretAccessKey: awsCreds.secret_key,
-    region: 'us-east-1'
-  });
-}
+const AWS = require("./src/aws")
+var http = require('http')
 
 // AWS services
-var sqs = new AWS.SQS(),
-    ecs = new AWS.ECS();
+const sqs = new AWS.SQS()
+const ecs = new AWS.ECS()
 
 // Listen on PORT (CloudFoundry pings this to make sure the script is running)
 http.createServer(function(req, res) {

--- a/app.js
+++ b/app.js
@@ -4,70 +4,16 @@ if (process.env.NEW_RELIC_APP_NAME && process.env.NEW_RELIC_LICENSE_KEY) {
   require('newrelic');
 }
 
-// ENV Vars
-const maxTasks = process.env.MAX_TASKS
-const port = process.env.PORT
-
-// Librarys
+// Start the health check server
 var http = require('http')
-
-// Setup cluster manager
-const Cluster = require("./src/cluster")
-const cluster = new Cluster()
-
-// Setup SQS client
-const SQSClient = require("./src/sqs-client")
-const sqsClient = new SQSClient()
-
-// Listen on PORT (CloudFoundry pings this to make sure the script is running)
 http.createServer(function(req, res) {
   log('Federalist-Builder started');
 
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('OK');
-}).listen(port || 8000);
+}).listen(process.env.PORT || 8000);
 
-// Start watching the queue
-checkQueue();
-
-// Check SQS queue
-function checkQueue() {
-  sqsClient.receiveMessage().then(message => {
-    if (message) {
-      checkCapacity(message)
-    }
-    checkQueue()
-  }).catch(err => {
-    error(err)
-    checkQueue()
-  })
-}
-
-// On message, check ECS task capacity and length
-function checkCapacity(message) {
-  cluster.countAvailableNodes().then(nodeCount => {
-    if (nodeCount < maxTasks) {
-      runTask(message)
-    }
-  }).catch(err => error(err))
-}
-
-// Run task and delete message once it's initialized
-function runTask(message) {
-  const containerOverrides = JSON.parse(message.Body)
-
-  cluster.runTask(containerOverrides).then(() => {
-    return sqsClient.deleteMessage(message)
-  }).catch(err => error(err))
-}
-
-// Handle errors
-function error(err) {
-  console.error(new Error(err));
-}
-
-function log(/** message, ...arguments**/) {
-  if (debugMode) {
-    console.log.apply(this, arguments);
-  }
-}
+// Start a BuildScheduler
+const BuildScheduler = require("./src/build-scheduler")
+const buildScheduler = new BuildScheduler()
+buildScheduler.start()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app",
-    "test": "exit 0"
+    "test": "`npm bin`/mocha"
   },
   "author": "dhcole",
   "license": "CC0",
@@ -13,5 +13,9 @@
     "aws-sdk": "^2.2.10",
     "cfenv": "^1.0.3",
     "newrelic": "^1.28.1"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.1.0"
   }
 }

--- a/src/aws.js
+++ b/src/aws.js
@@ -1,0 +1,15 @@
+const AWS = require("aws-sdk")
+const cfenv = require("cfenv")
+
+const appEnv = cfenv.getAppEnv()
+const awsCredentials = appEnv.getServiceCreds('federalist-aws-user')
+
+if (awsCredentials) {
+  AWS.config.update({
+    accessKeyId: awsCredentials.access_key,
+    secretAccessKey: awsCredentials.secret_key,
+    region: 'us-east-1'
+  });
+}
+
+module.exports = AWS

--- a/src/build-scheduler.js
+++ b/src/build-scheduler.js
@@ -1,0 +1,59 @@
+const Cluster = require("./cluster")
+const SQSClient = require("./sqs-client")
+
+class BuildScheduler {
+  constructor() {
+    this._cluster = new Cluster()
+    this._sqsClient = new SQSClient()
+  }
+
+  start() {
+    this.running = true
+    this._run()
+  }
+
+  stop() {
+    this.running = false
+  }
+
+  _run() {
+    this._findAndScheduleNewBuild().catch(error => {
+      console.error(error)
+    }).then(() => {
+      if (this.running) {
+        setImmediate(() => {
+          this._run()
+        })
+      }
+    })
+  }
+
+  _attemptToRunTaskForMessage(message) {
+    return this._cluster.countAvailableNodes().then(availableNodes => {
+      if (availableNodes > 0) {
+        return this._runTaskAndDeleteMessage(message)
+      }
+    })
+  }
+
+  _containerOverridesForMessage(message) {
+    return JSON.parse(message.Body)
+  }
+
+  _findAndScheduleNewBuild() {
+    return this._sqsClient.receiveMessage().then(message => {
+      if (message) {
+        return this._attemptToRunTaskForMessage(message)
+      }
+    })
+  }
+
+  _runTaskAndDeleteMessage(message) {
+    const containerOverrides = this._containerOverridesForMessage(message)
+    return this._cluster.runTask(containerOverrides).then(() => {
+      return this._sqsClient.deleteMessage(message)
+    })
+  }
+}
+
+module.exports = BuildScheduler

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -1,0 +1,78 @@
+const AWS = require("./aws")
+
+class Cluster {
+  constructor() {
+    this.capacity = process.env.MAX_TASKS || 1
+    this._ecs = new AWS.ECS()
+  }
+
+  countAvailableNodes() {
+    const params = this._ecsDescriptionParams()
+
+    return new Promise((resolve, reject) => {
+      this._ecs.describeClusters(params, (err, data) => {
+        if (err) {
+          reject(err)
+        } else if (data.clusters.length == 0) {
+          reject(new ClusterNotPresentInECSCallbackError())
+        } else {
+          const cluster = data.clusters[0]
+          const busyNodeCount = cluster.runningTasksCount + cluster.pendingTasksCount
+          resolve(this.capacity - busyNodeCount)
+        }
+      })
+    })
+  }
+
+  runTask(containerOverrides) {
+    const params = this._ecsTaskParams(containerOverrides)
+
+    return new Promise((resolve, reject) => {
+      this._ecs.runTask(params, (err, data) => {
+        if (err) {
+          reject(err)
+        } else if (data.tasks.length == 0) {
+          reject(new TaskNotPresentInECSCallbackError())
+        } else {
+          resolve(data.tasks[0])
+        }
+      })
+    })
+  }
+
+  _ecsClustName() {
+    return process.env.ECS_CLUSTER || "default"
+  }
+
+  _ecsDescriptionParams() {
+    return {
+      clusters: [ this._ecsClustName() ]
+    }
+  }
+
+  _ecsTaskDefinition() {
+    return process.env.ECS_TASK
+  }
+
+  _ecsTaskParams(containerOverrides) {
+    return {
+      taskDefinition: this._ecsTaskDefinition(),
+      cluster: this._ecsClustName(),
+      overrides: { containerOverrides: [ containerOverrides ] }
+    }
+  }
+}
+
+class ClusterNotPresentInECSCallbackError extends Error {
+  constructor() {
+    super("ECS.DescribeClusters called back with a response that did not include any clusters")
+  }
+}
+
+class TaskNotPresentInECSCallbackError extends Error {
+  constructor() {
+    super("ECS.RunTask called back with a response that did not include any tasks")
+  }
+}
+
+module.exports = Cluster

--- a/src/sqs-client.js
+++ b/src/sqs-client.js
@@ -1,0 +1,60 @@
+const AWS = require("./aws")
+
+class SQSClient {
+  constructor() {
+    this._sqs = new AWS.SQS()
+  }
+
+  receiveMessage() {
+    var params = this._sqsReceiveMessageParams()
+
+    return new Promise((resolve, reject) => {
+      this._sqs.receiveMessage(params, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          let message
+          if (data && data.Messages && data.Messages[0]) {
+            message = data.Messages[0]
+          }
+          resolve(message)
+        }
+      })
+    })
+  }
+
+  deleteMessage(message) {
+    const params = this._sqsDeleteMessageParams(message)
+
+    return new Promise((resolve, reject) => {
+      this._sqs.deleteMessage(params, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(message)
+        }
+      })
+    })
+  }
+
+  _sqsDeleteMessageParams(message) {
+    return {
+      QueueUrl: this._sqsQueueURL(),
+      ReceiptHandle: message.ReceiptHandle,
+    }
+  }
+
+  _sqsQueueURL() {
+    return process.env.SQS_URL
+  }
+
+  _sqsReceiveMessageParams() {
+    return {
+      QueueUrl: this._sqsQueueURL(),
+      MaxNumberOfMessages: 1,
+      WaitTimeSeconds: 20,
+    }
+  }
+}
+
+module.exports = SQSClient

--- a/test/build-scheduler.js
+++ b/test/build-scheduler.js
@@ -1,0 +1,123 @@
+process.env.SQS_URL = "https://sqs.us-east-1.amazonaws.com/123abc/456def"
+process.env.ECS_CLUSTER = "ECS_CLUSTER"
+process.env.ECS_TASK = "federalist-builder"
+process.env.MAX_TASKS = 10
+process.env.PORT = 3000
+
+const expect = require("chai").expect
+const BuildScheduler = require("../src/build-scheduler")
+
+describe("BuildScheduler", () => {
+  it("it should run a task when a message is received from SQS and then delete the message", (done) => {
+    let hasReceivedMessage = false
+    const sqs = {}
+    sqs.receiveMessage = (params, callback) => {
+      if (!hasReceivedMessage) {
+        hasReceivedMessage = true
+        callback(null, {
+          Messages: [
+            {
+              Body: "{}"
+            }
+          ]
+        })
+      } else {
+        mockedSQSReceiveMessage(params, callback)
+      }
+    }
+
+    let hasDeletedMessage = false
+    sqs.deleteMessage = (params, callback) => {
+      hasDeletedMessage = true
+      mockedSQSDeleteMessage(params, callback)
+    }
+
+    let hasRunTask = false
+    const ecs = {}
+    ecs.runTask = (params, callback) => {
+      hasRunTask = true
+      mockedECSRunTask(params, callback)
+    }
+
+    const buildScheduler = new BuildScheduler()
+    mockECSServices(buildScheduler, { sqs, ecs })
+    buildScheduler.start()
+
+    setImmediate(() => {
+      expect(hasReceivedMessage).to.equal(true)
+      expect(hasRunTask).to.equal(true)
+      expect(hasDeletedMessage).to.equal(true)
+      buildScheduler.stop()
+      done()
+    })
+  })
+
+  it("should not run more tasks than the cluster can handle", (done) => {
+    let receivedMessageCount = 0
+    const sqs = {}
+    sqs.receiveMessage = (params, callback) => {
+      receivedMessageCount++
+      callback(null, {
+        Messages: [
+          {
+            Body: "{}"
+          }
+        ]
+      })
+    }
+
+    let runningTasksCount = 0
+    const ecs = {}
+    ecs.runTask = (params, callback) => {
+      runningTasksCount++
+      mockedECSRunTask(params, callback)
+    }
+    ecs.describeClusters = (params, callback) => callback(null, {
+      clusters: [
+        {
+          runningTasksCount: runningTasksCount,
+          pendingTasksCount: 0,
+        },
+      ],
+    })
+
+    const buildScheduler = new BuildScheduler()
+    mockECSServices(buildScheduler, { sqs, ecs })
+    buildScheduler.start()
+
+    setTimeout(() => {
+      expect(receivedMessageCount).to.be.above(10)
+      expect(runningTasksCount).to.equal(10)
+      buildScheduler.stop()
+      done()
+    }, 250)
+  })
+})
+
+const mockECSServices = (buildScheduler, { sqs, ecs }) => {
+  buildScheduler._sqsClient._sqs = Object.assign({
+    receiveMessage: mockedSQSReceiveMessage,
+    deleteMessage: mockedSQSDeleteMessage,
+  }, sqs)
+  buildScheduler._cluster._ecs = Object.assign({
+    describeClusters: mockedECSDescribeClusters,
+    runTask: mockedECSRunTask,
+  }, ecs)
+}
+
+const mockedSQSReceiveMessage = (params, callback) => callback(null, {
+  Messages: [],
+})
+
+const mockedSQSDeleteMessage = (params, callback) => callback()
+
+const mockedECSDescribeClusters = (params, callback) => callback(null, {
+  clusters: [
+    {
+      runningTasksCount: 0,
+      pendingTasksCount: 0,
+    },
+  ],
+})
+
+const mockedECSRunTask = (params, callback) => callback(null, { tasks: [{}] })

--- a/test/cluster-test.js
+++ b/test/cluster-test.js
@@ -1,0 +1,98 @@
+process.env.ECS_TASK = "federalist-builder"
+process.env.ECS_CLUSTER = "default"
+process.env.MAX_TASKS = 10
+
+const expect = require("chai").expect
+const Cluster = require("../src/cluster")
+
+describe("Cluster", () => {
+  describe(".runTask(containerOverrides)", () => {
+    it("should call ECS.RunTask with the given container overrides", (done) => {
+      const containerOverrides = {
+        environment: [
+          { name: "key", value: "value" }
+        ],
+        name: "builder"
+      }
+
+      const cluster = new Cluster()
+      cluster._ecs.runTask = (params, callback) => {
+        const containerOverridesFromParams = params.overrides.containerOverrides[0]
+        expect(containerOverridesFromParams).to.equal(containerOverrides)
+        done()
+      }
+
+      cluster.runTask(containerOverrides)
+    })
+
+    it("should call ECS.RunTask and reject with an error if ECS returns an error", (done) => {
+      const cluster = new Cluster()
+      cluster._ecs.runTask = (params, callback) => {
+        callback(new Error("test error"))
+      }
+
+      cluster.runTask({}).catch(error => {
+        expect(error.message).to.match(/test error/)
+        done()
+      })
+    })
+
+    it("should call ECS.RunTask with the correct task definition and cluster name", (done) => {
+      const cluster = new Cluster()
+      cluster._ecs.runTask = (params, callback) => {
+        expect(params.taskDefinition).to.equal(process.env.ECS_TASK)
+        expect(params.cluster).to.equal(process.env.ECS_CLUSTER)
+        done()
+      }
+
+      cluster.runTask({})
+    })
+  })
+
+  describe(".countAvailableNodes()", () => {
+    it("should call ECS.DescribeCluster and resolve with the number of available nodes", (done) => {
+      const cluster = new Cluster()
+
+      cluster._ecs.describeClusters = (params, callback) => {
+        const data = {
+          clusters: [
+            {
+              runningTasksCount: 2,
+              pendingTasksCount: 3,
+            }
+          ]
+        }
+        callback(null, data)
+      }
+
+      cluster.countAvailableNodes().then(nodeCount => {
+        expect(nodeCount).to.equal(5)
+        done()
+      })
+    })
+
+    it("should call ECS.DescribeCluster and reject with an error if ECS responds with an error", (done) => {
+      const cluster = new Cluster()
+
+      cluster._ecs.describeClusters = (params, callback) => {
+        callback(new Error("test error"))
+      }
+
+      cluster.countAvailableNodes().catch(error => {
+        expect(error.message).to.match(/test error/)
+        done()
+      })
+    })
+
+    it("should call ECS.DescribeCluster on the correct cluster", (done) => {
+      const cluster = new Cluster()
+
+      cluster._ecs.describeClusters = (params, callback) => {
+        expect(params.clusters).to.deep.equal([process.env.ECS_CLUSTER])
+        done()
+      }
+
+      cluster.countAvailableNodes()
+    })
+  })
+})

--- a/test/sqs-client-test.js
+++ b/test/sqs-client-test.js
@@ -1,0 +1,108 @@
+process.env.SQS_URL = "https://sqs.us-east-1.amazonaws.com/123abc/456def"
+
+let expect = require("chai").expect
+let SQSClient = require("../src/sqs-client")
+
+describe("SQSClient", () => {
+  describe(".receiveMessage()", () => {
+    it("should call SQS.ReceiveMessage and responds with a message", (done) => {
+      const message = {
+        Body: JSON.stringify({
+          environment: [
+            { name: "key", value: "value" }
+          ],
+          name: "builder"
+        }),
+      }
+
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.receiveMessage = (params, callback) => {
+          callback(null, { Messages: [ message ] })
+      }
+
+      sqsClient.receiveMessage().then(receivedMessage => {
+        expect(receivedMessage).to.deep.equal(message)
+        done()
+      })
+    })
+
+    it("should call SQS.ReceiveMessage and respond with undefined if there are no messages", (done) => {
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.receiveMessage = (params, callback) => {
+          callback(null, { Messages: [] })
+      }
+
+      sqsClient.receiveMessage().then(receivedMessage => {
+        expect(receivedMessage).to.deep.be.undefined
+        done()
+      })
+    })
+
+    it("should call SQS.ReceiveMessage and reject with an error if SQS responds with an error", (done) => {
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.receiveMessage = (params, callback) => {
+        callback(new Error("test error"), { Messages: [] })
+      }
+
+      sqsClient.receiveMessage().catch(error => {
+        expect(error.message).to.equal("test error")
+        done()
+      })
+    })
+
+    it("should call SQS.ReceiveMessage with the correct queue URL", (done) => {
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.receiveMessage = (params, callback) => {
+        expect(params.QueueUrl).to.equal(process.env.SQS_URL)
+        done()
+      }
+
+      sqsClient.receiveMessage({})
+    })
+  })
+
+  describe(".deleteMessage(message)", () => {
+    it("should call SQS.DeleteMessage with the message's receipt handle", (done) => {
+      const message = {
+        ReceiptHandle: "mocked-receipt-handle",
+      }
+
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.deleteMessage = (params, callback) => {
+        expect(params.ReceiptHandle).to.equal("mocked-receipt-handle")
+        done()
+      }
+
+      sqsClient.deleteMessage(message)
+    })
+
+    it("should call SQS.DeleteMessage and reject with an error if SQS response with an error", (done) => {
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.deleteMessage = (params, callback) => {
+        callback(new Error("test error"))
+      }
+
+      sqsClient.deleteMessage({}).catch(error => {
+        expect(error.message).to.equal("test error")
+        done()
+      })
+    })
+
+    it("should call SQS.DeleteMessage with the correct queue URL", (done) => {
+      const sqsClient = new SQSClient()
+
+      sqsClient._sqs.deleteMessage = (params, callback) => {
+        expect(params.QueueUrl).to.equal(process.env.SQS_URL)
+        done()
+      }
+
+      sqsClient.deleteMessage({})
+    })
+  })
+})


### PR DESCRIPTION
This PR represent a major refactor to introduce some modularization that makes it a bit simpler to use and reason about the app.

The motivation for this is moving site builds out of ECS and onto Diego (ref: 18F/federalist#542). It was tough to reason about exactly what needed to be changed and where. Additionally, there was limited confidence that bugs where not being introduced because there were no tests and adding tests to the previous implementation was difficult.

This commit breaks the app into some simple modules to separate the concerns and add the ability to write unit tests.

The new parts are:

- Cluster: Communicates between the app and the ECS cluster. In the future, this will communicate with the cluster in cloud.gov
- SQSClient: Communicates between the app and SQS
- BuildScheduler: Reads messages from SQS and runs builds on the cluster in response

This PR also sets up a testing toolchain and adds some tests