### PR TITLE
Disable shrinkwrap when installing npm modules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shrinkwrap=false


### PR DESCRIPTION
Hapi was installing a version of moment which has a ReDOS vulnerability. The path to that dependency looks like this:

```
hapi@15.2.0 > joi@9.0.4 > moment@2.14.1
```

The `package.json` for `joi@9.0.4` allows joi to install any version of moment that matches `2.x.x`. Unfortunatly this was not happening because Hapi's dependencies are shrinkwrapped.

ref: https://github.com/hapijs/joi/blob/v9.0.4/package.json#L20
ref: https://github.com/hapijs/hapi/blob/v15.0.2/npm-shrinkwrap.json#L45

This commit disables shrinkwrapping when running npm install so that we can get the updated version of moment, and in the future get more recent versions of other packages.