### PR TITLE
Adjust build timeout to 21 minutes

### DIFF
--- a/src/cluster.js
+++ b/src/cluster.js
@@ -100,7 +100,7 @@ class Cluster {
     container.timeout = setTimeout(() => {
       winston.warn("Build %s timed out", build.buildID)
       this.stopBuild(build.buildID)
-    }, 300 * 1000)
+    }, 21 * 60 * 1000)
     return this._apiClient.updateBuildContainer(
       container,
       build.containerEnvironment


### PR DESCRIPTION
This commit adjusts the timeout that determines how long builds have to run before they're considered dead to 21 minutes. This is done because some bigger sites (like 18f.gsa.gov) can take 15 - 20 minutes to build.

Ref 18F/federalist#693