### PR TITLE
Bump Travis's node version to v6.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: true
 node_js:
-- "6.6.0"
+- 6.9
 env:
   global:
   - CF_API=https://api.fr.cloud.gov


### PR DESCRIPTION
This commit bump the node version we use on Travis to 6.9 which is the LTS and the version we use on cloud.gov.