### PR TITLE
Reduce instance memory from 512MB to 128MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
 domain: fr.cloud.gov
 hostname: federalist-builder
 disk_quota: 512M
-memory: 512M
+memory: 128MB
 instances: 1
 services:
 - federalist-ew-sqs-user

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -4,7 +4,7 @@ applications:
 domain: fr.cloud.gov
 hostname: federalist-builder-staging
 disk_quota: 512M
-memory: 512M
+memory: 128MB
 instances: 1
 services:
 - federalist-ew-sqs-user


### PR DESCRIPTION
The Federalist web application uses about 60MB-70MB of RAM. With this in mind, this commit scales the memory the app is allocated in cloud.gov from 512MB to 128MB, which should free up some memory in our org, while leaving overhead for memory spikes.