### PR TITLE
Report build timeouts back to main Federalist web application

### DIFF
--- a/src/build-timeout-reporter.js
+++ b/src/build-timeout-reporter.js
@@ -1,0 +1,54 @@
+const request = require("request")
+const winston = require("winston")
+
+class BuildTimeoutReporter {
+  constructor(build) {
+    this._build = build
+  }
+
+  reportBuildTimeout() {
+    return Promise.all([
+      this._sendBuildLogRequest(),
+      this._sendBuildStatusRequest(),
+    ]).catch(err => {
+      winston.error("Error reporting build timeout:", err)
+    })
+  }
+
+  _request(method, url, body) {
+    return new Promise((resolve, reject) => {
+      request({
+        method: method.toUpperCase(),
+        url,
+        json: body,
+      }, (error, response, body) => {
+        if (error) {
+          reject(error)
+        } else if (response.statusCode > 399) {
+          let errorMessage = `Received status code: ${response.statusCode}`
+          reject(new Error(body || errorMessage))
+        } else {
+          resolve(body)
+        }
+      })
+    })
+  }
+
+  _sendBuildLogRequest() {
+    const url = this._build.containerEnvironment.LOG_CALLBACK
+    return this._request("POST", url, {
+      message: "The build timed out",
+      source: "Build scheduler",
+    })
+  }
+
+  _sendBuildStatusRequest() {
+    const url = this._build.containerEnvironment.STATUS_CALLBACK
+    return this._request("POST", url, {
+      message: Buffer.from("The build timed out").toString("base64"),
+      status: "1",
+    })
+  }
+}
+
+module.exports = BuildTimeoutReporter

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -1,6 +1,7 @@
 const url = require("url")
 const winston = require("winston")
 const AWS = require("./aws")
+const BuildTimeoutReporter = require("./build-timeout-reporter")
 const CloudFoundryAPIClient = require("./cloud-foundry-api-client")
 const server = require("./server")
 
@@ -45,6 +46,7 @@ class Cluster {
     const container = this._findBuildContainer(buildID)
     if (container) {
       clearTimeout(container.timeout)
+      new BuildTimeoutReporter(container.build).reportBuildTimeout()
       container.build = undefined
     } else {
       winston.warn("Unable to stop build %s. Container not found.", buildID)

--- a/test/build-timeout-reporter.test.js
+++ b/test/build-timeout-reporter.test.js
@@ -1,0 +1,35 @@
+const expect = require("chai").expect
+const nock = require("nock")
+const url = require("url")
+const mockBuildLogCallback = require("./nocks/build-log-callback-nock")
+const mockBuildStatusCallback = require("./nocks/build-status-callback-nock")
+
+const BuildTimeoutReporter = require("../src/build-timeout-reporter")
+
+describe("BuildTimeoutReporter", () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe("reportBuildTimeout", () => {
+    it("should send a request to the build's status and log callback", done => {
+      const logURL = url.parse("https://www.example.gov/log")
+      const statusURL = url.parse("https://www.example.gov/status")
+      const logCallbackNock = mockBuildLogCallback(logURL)
+      const statusCallbackNock = mockBuildStatusCallback(statusURL)
+
+      const build = {
+        containerEnvironment: {
+          LOG_CALLBACK: logURL.href,
+          STATUS_CALLBACK: statusURL.href,
+        }
+      }
+
+      new BuildTimeoutReporter(build).reportBuildTimeout().then(() => {
+        expect(logCallbackNock.isDone()).to.be.true
+        expect(statusCallbackNock.isDone()).to.be.true
+        done()
+      }).catch(done)
+    })
+  })
+})

--- a/test/cluster-test.js
+++ b/test/cluster-test.js
@@ -1,8 +1,11 @@
 const expect = require("chai").expect
-
 const nock = require("nock")
+const url = require("url")
+
 const Cluster = require("../src/cluster")
 
+const mockBuildLogCallback = require("./nocks/build-log-callback-nock")
+const mockBuildStatusCallback = require("./nocks/build-status-callback-nock")
 const mockListAppsRequest = require("./nocks/cloud-foundry-list-apps-nock")
 const mockRestageAppRequest = require("./nocks/cloud-foundry-restage-app-nock")
 const mockTokenRequest = require("./nocks/cloud-foundry-oauth-token-nock")
@@ -102,6 +105,20 @@ describe("Cluster", () => {
   })
 
   describe(".stopBuild(buildID)", () => {
+    const logCallbackURL = url.parse("https://www.example.gov/log")
+    const statusCallbackURL = url.parse("https://www.example.gov/status")
+    let logCallbackNock
+    let statusCallbackNock
+
+    beforeEach(() => {
+      logCallbackNock = mockBuildLogCallback(logCallbackURL)
+      statusCallbackNock = mockBuildStatusCallback(statusCallbackURL)
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
     it("should make the build for the given buildID available", () => {
       const cluster = new Cluster()
 
@@ -110,6 +127,10 @@ describe("Cluster", () => {
           guid: "123abc",
           build: {
             buildID: "456def",
+            containerEnvironment: {
+              LOG_CALLBACK: logCallbackURL.href,
+              STATUS_CALLBACK: statusCallbackURL.href,
+            },
           },
         },
         {
@@ -124,6 +145,31 @@ describe("Cluster", () => {
 
       expect(container).to.be.a("object")
       expect(container.build).to.be.undefined
+    })
+
+    it("should send a request to the build's log and status callback", done => {
+      const cluster = new Cluster()
+
+      cluster._containers = [
+        {
+          guid: "123abc",
+          build: {
+            buildID: "456def",
+            containerEnvironment: {
+              LOG_CALLBACK: logCallbackURL.href,
+              STATUS_CALLBACK: statusCallbackURL.href,
+            },
+          }
+        }
+      ]
+
+      cluster.stopBuild("456def")
+
+      setTimeout(() => {
+        expect(logCallbackNock.isDone()).to.be.true
+        expect(statusCallbackNock.isDone()).to.be.true
+        done()
+      }, 200)
     })
   })
 })

--- a/test/nocks/build-log-callback-nock.js
+++ b/test/nocks/build-log-callback-nock.js
@@ -1,0 +1,12 @@
+const nock = require("nock")
+
+const mockBuildLogCallback = (url) => {
+  const message = "The build timed out"
+  const source = "Build scheduler"
+
+  return nock(`${url.protocol}//${url.hostname}`)
+    .post(url.path, { message, source })
+    .reply(200)
+}
+
+module.exports = mockBuildLogCallback

--- a/test/nocks/build-status-callback-nock.js
+++ b/test/nocks/build-status-callback-nock.js
@@ -1,0 +1,15 @@
+const nock = require("nock")
+
+const mockBuildStatusCallback = (url) => {
+  const timeoutMessage = "The build timed out"
+  const encodedTimeoutMessage = Buffer.from(timeoutMessage).toString("base64")
+
+  return nock(`${url.protocol}//${url.hostname}`)
+    .post(url.path, {
+      status: "1",
+      message: encodedTimeoutMessage,
+    })
+    .reply(200)
+}
+
+module.exports = mockBuildStatusCallback


### PR DESCRIPTION
This commit adds a new class named `BuildTimeoutReporter`. When a build times out, the class is invoked to send a request to the build's `LOG_CALLBACK` and `STATUS_CALLBACK` URL, alerting the Federalist web application that the build has timed out.

Prior to this commit, no such alert existed, so builds that timed out in this manner appeared to run forever.

Ref #15
Ref 18f/federalist#737