### PR TITLE
Use correct params for build log request

### DIFF
--- a/src/build-timeout-reporter.js
+++ b/src/build-timeout-reporter.js
@@ -37,7 +37,7 @@ class BuildTimeoutReporter {
   _sendBuildLogRequest() {
     const url = this._build.containerEnvironment.LOG_CALLBACK
     return this._request("POST", url, {
-      message: "The build timed out",
+      output: "The build timed out",
       source: "Build scheduler",
     })
   }

--- a/test/nocks/build-log-callback-nock.js
+++ b/test/nocks/build-log-callback-nock.js
@@ -1,11 +1,11 @@
 const nock = require("nock")
 
 const mockBuildLogCallback = (url) => {
-  const message = "The build timed out"
+  const output = "The build timed out"
   const source = "Build scheduler"
 
   return nock(`${url.protocol}//${url.hostname}`)
-    .post(url.path, { message, source })
+    .post(url.path, { output, source })
     .reply(200)
 }
 


### PR DESCRIPTION
The BuildTimeoutReporter was using the incorrect params to send a request to create a build log, resulting in build logs not being created when builds timed out. This commit changes the reporter to use the correct params.