### PR TITLE
Only send build timeout message when builds timeout

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,7 @@ services:
 - federalist-ew-sqs-user
 - federalist-deploy-user
 env:
+  BUILD_TIMEOUT_SECONDS: 1200
   SQS_URL: "https://sqs.us-west-2.amazonaws.com/144433228153/federalist-builds-cloudgov"
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder.fr.cloud.gov"
   BUILD_CONTAINER_DOCKER_IMAGE_NAME: "federalist-registry.fr.cloud.gov/federalist-docker-build"

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -46,11 +46,15 @@ class Cluster {
     const container = this._findBuildContainer(buildID)
     if (container) {
       clearTimeout(container.timeout)
-      new BuildTimeoutReporter(container.build).reportBuildTimeout()
       container.build = undefined
     } else {
       winston.warn("Unable to stop build %s. Container not found.", buildID)
     }
+  }
+
+  _buildTimeoutMilliseconds() {
+    const timeoutSeconds = parseInt(process.env.BUILD_TIMEOUT_SECONDS) || 21 * 60
+    return timeoutSeconds * 1000
   }
 
   _firstAvailableContainer() {
@@ -101,8 +105,8 @@ class Cluster {
     container.build = build
     container.timeout = setTimeout(() => {
       winston.warn("Build %s timed out", build.buildID)
-      this.stopBuild(build.buildID)
-    }, 21 * 60 * 1000)
+      this._timeoutBuild(build)
+    }, this._buildTimeoutMilliseconds())
     return this._apiClient.updateBuildContainer(
       container,
       build.containerEnvironment
@@ -111,6 +115,11 @@ class Cluster {
       clearTimeout(container.timeout)
       throw error
     })
+  }
+
+  _timeoutBuild(build) {
+    this.stopBuild(build.buildID)
+    new BuildTimeoutReporter(build).reportBuildTimeout()
   }
 }
 

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -10,6 +10,7 @@ services:
 - federalist-ew-sqs-user
 - federalist-deploy-user
 env:
+  BUILD_TIMEOUT_SECONDS: 1200
   SQS_URL: "https://sqs.us-east-1.amazonaws.com/144433228153/federalist-builds-staging"
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder-staging.fr.cloud.gov"
   BUILD_CONTAINER_DOCKER_IMAGE_NAME: "federalist-registry-staging.fr.cloud.gov/federalist-docker-build"


### PR DESCRIPTION
Prior to this commit, the `BuildTimeoutReporter` was invoked in `Cluster.stopBuild`. This mean a timeout was reported any time a build was stopped, regardless of whether or not the build was stopped because it timed out or because it completed successfully.

This commit adds a new function for stopping builds that timeout and reporting a timeout. It also adds better test coverage for timeout behavior to prevent this error from appearing in the future.