### PR TITLE
Encode timeout messages as a base64 string

### DIFF
--- a/src/build-timeout-reporter.js
+++ b/src/build-timeout-reporter.js
@@ -36,14 +36,16 @@ class BuildTimeoutReporter {
 
   _sendBuildLogRequest() {
     const url = this._build.containerEnvironment.LOG_CALLBACK
+    winston.verbose(`Sending timeout log request for ${this._build.buildID}`)
     return this._request("POST", url, {
-      output: "The build timed out",
+      output: Buffer.from("The build timed out").toString("base64"),
       source: "Build scheduler",
     })
   }
 
   _sendBuildStatusRequest() {
     const url = this._build.containerEnvironment.STATUS_CALLBACK
+    winston.verbose(`Sending timeout status request for ${this._build.buildID}`)
     return this._request("POST", url, {
       message: Buffer.from("The build timed out").toString("base64"),
       status: "1",

--- a/test/nocks/build-log-callback-nock.js
+++ b/test/nocks/build-log-callback-nock.js
@@ -1,11 +1,12 @@
 const nock = require("nock")
 
 const mockBuildLogCallback = (url) => {
-  const output = "The build timed out"
+  const timeoutMessage = "The build timed out"
+  const encodedTimeoutMessage = Buffer.from(timeoutMessage).toString("base64")
   const source = "Build scheduler"
 
   return nock(`${url.protocol}//${url.hostname}`)
-    .post(url.path, { output, source })
+    .post(url.path, { output: encodedTimeoutMessage, source })
     .reply(200)
 }
 


### PR DESCRIPTION
The build container now sends build logs to the federalist application
as a base64 enconded string. This commit matches that behavior in the
BuildTimeoutReporter when it reports a build timeout to the build log
API.