### PR TITLE
Select cf creds based on environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ node_js:
 env:
   global:
   - CF_API=https://api.fr.cloud.gov
-  - CF_USERNAME=gsa-18f-federalist_deployer
   - CF_ORGANIZATION=gsa-18f-federalist
-  # CF_PASSWORD for gsa-18f-federalist_deployer user
-  - secure: "ovjRuWHniFKz+Yr6eOO89E8LZhxs1BRdqpGdljZnf70XsdoldqdVN0Lr0Vd1zJMD/ep5TPfaT9h4VADB9JqMF1ODWmX7LiJ2W7GP309S9KWDUkUbl5xOp4mCMl0XDlStwLZeIcPt6Oa2UpSQCnjFMUK1KLBEGC/8vxtp4X18VjPmZ2V9Uu6lMB6Fe2fZbx7N7QWsQjciwUd1bVyseIMHCSGWeZ3OZARxBsfJT7ZwHX5zD8xT3IfHSUArDhYYM5+Q/ApP+MK3N9gZXukKeq6/2V4t8WNuCPEqcJH/eRBKu5IS/ddk09KXWS51aMdU0zC4/LL/sSvOsdufPf+e6Ha2RZV+6BoWFFSZKRWpCSpVNj6ORSGICCudFtC4oIJaTKB1qqcAjT/fB7iuHsWnymUNTpHDIAeuOA4kvwTLG0LnrPxfe6Midpx4ceYb+Jv0BIosVKK2ZoLsQDSGgOLYvhw4nhzqbo8jHkmq8PhZUODiK7vlwIZWwnFkvqkmKHEKILeTikZ4Gx5DWbMB/AAlp/NSLZHVRz+ARKZ3qKe5wUgDkbkCuDqEOq7xnUN8g05Kp8NlIbEI7JJjrgbSfjBUqApTLyjwEx94bw6Wo7iVexBzW0l+TsoIiI5FkgWFrM8YFXEunBpwMpzJ6fr0EMFWnxzVvH8yhMewS7O1tn+gqhPtoNg="
 before_deploy:
   - export PATH=$HOME:$PATH
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.1"

--- a/scripts/deploy-travis.sh
+++ b/scripts/deploy-travis.sh
@@ -4,11 +4,15 @@ set -e
 
 if [ "$TRAVIS_BRANCH" == "master" ]
 then
+  CF_USERNAME=$CF_USERNAME_PRODUCTION
+  CF_PASSWORD=$CF_PASSWORD_PRODUCTION
   CF_SPACE="production"
   CF_APP="federalist-builder"
   CF_MANIFEST="manifest.yml"
 elif [ "$TRAVIS_BRANCH" == "staging" ]
 then
+  CF_USERNAME=$CF_USERNAME_STAGING
+  CF_PASSWORD=$CF_PASSWORD_STAGING
   CF_SPACE="staging"
   CF_APP="federalist-builder-staging"
   CF_MANIFEST="staging_manifest.yml"


### PR DESCRIPTION
This commit changes the way credentials are set during CI deploys so that different environments have different credentials. It also removes the credentials from the Travis config, setting them in Travis env vars instead so they can be rotated without changing the code.