### PR TITLE
Fix New Relic APM monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ The SQS message body should be JSON that takes the form of an ECS task override 
 }
 ```
 
+Private configuration values should be in a cloud.gov user-provided service named `federalist-builder-env`:
+
+- `NEW_RELIC_LICENSE_KEY` the private New Relic license key
+
 Additional configuration is set up through environment variables:
 
+- `BUILD_TIMEOUT_SECONDS`: (required) number of seconds to let a build run before timing out
 - `BUILD_COMPLETE_CALLBACK_HOST` (required) the host that a build container should callback to when finished, e.g. `https://federalist-builder.18f.gov`
 - `BUILD_CONTAINER_DOCKER_IMAGE_NAME` (required) the name of the docker image that is used to run builds
 - `BUILD_SPACE_GUID` (required) the guid for the cloud.gov space where the build containers are located
@@ -66,7 +71,6 @@ Additional configuration is set up through environment variables:
 - `DEPLOY_USER_PASSWORD` (required) the password for the deploy user that starts builds in cloud.gov.
 - `LOG_LEVEL` the log level for [winston](https://github.com/winstonjs/winston#logging-levels). Defaults to "info".
 - `NEW_RELIC_APP_NAME` the name of the app in New Relic
-- `NEW_RELIC_LICENSE_KEY` the license key for the app in New Relic
 - `PORT` the port for the server that handles healthcheck pings and build callbacks
 - `SQS_URL` (required) the URL of the SQS queue to poll
 

--- a/app.js
+++ b/app.js
@@ -1,16 +1,20 @@
-// Setup winston for logging
+const cfenv = require('cfenv');
 const winston = require('winston');
 
+const BuildScheduler = require('./src/build-scheduler');
+
+// Setup winston for logging
 winston.level = process.env.LOG_LEVEL || 'info';
 
 // If settings present, start New Relic
-if (process.env.NEW_RELIC_APP_NAME && process.env.NEW_RELIC_LICENSE_KEY) {
-  winston.info('Activating New Relic: ', process.env.NEW_RELIC_APP_NAME);
-  require('newrelic'); // eslint-disable-line global-require
+if (process.env.NEW_RELIC_APP_NAME) {
+  const creds = cfenv.getAppEnv().getServiceCreds('federalist-builder-env');
+  if (creds.NEW_RELIC_LICENSE_KEY) {
+    winston.info(`Activating New Relic: ${process.env.NEW_RELIC_APP_NAME}`);
+    require('newrelic'); // eslint-disable-line global-require
+  }
 }
 
 // Start a BuildScheduler
-const BuildScheduler = require('./src/build-scheduler');
-
 const buildScheduler = new BuildScheduler();
 buildScheduler.start();

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,9 @@ instances: 1
 services:
 - federalist-ew-sqs-user
 - federalist-deploy-user
+- federalist-builder-env
 env:
+  NEW_RELIC_APP_NAME: "federalist-builder-prod"
   BUILD_TIMEOUT_SECONDS: 1200
   SQS_URL: "https://sqs.us-west-2.amazonaws.com/144433228153/federalist-builds-cloudgov"
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder.fr.cloud.gov"

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,16 +1,19 @@
+const cfenv = require('cfenv');
+
+const creds = cfenv.getAppEnv().getServiceCreds('federalist-builder-env');
+
 /**
  * New Relic agent configuration.
  *
- * See lib/config.defaults.js in the agent distribution for a more complete
+ * This file is require'd by the new relic lib, not directly by our code.
+ *
+ * See node_modules/lib/config.defaults.js in the agent distribution for a more complete
  * description of configuration variables and their potential values.
  */
 exports.config = {
+  app_name: [process.env.NEW_RELIC_APP_NAME],
+  license_key: creds.NEW_RELIC_LICENSE_KEY,
   logging: {
-    /**
-     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
-     * issues with the agent, 'info' and higher will impose the least overhead on
-     * production applications.
-     */
     level: 'info',
   },
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cfenv": "^1.0.3",
     "hapi": "^15.1.1",
     "jsonwebtoken": "^7.1.9",
-    "newrelic": "^1.28.1",
+    "newrelic": "^2.0.0",
     "request": "^2.75.0",
     "winston": "^2.2.0"
   },

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -9,7 +9,9 @@ instances: 1
 services:
 - federalist-ew-sqs-user
 - federalist-deploy-user
+- federalist-builder-env
 env:
+  NEW_RELIC_APP_NAME: "federalist-builder-staging"
   BUILD_TIMEOUT_SECONDS: 1200
   SQS_URL: "https://sqs.us-east-1.amazonaws.com/144433228153/federalist-builds-staging"
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder-staging.fr.cloud.gov"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@newrelic/native-metrics@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/native-metrics/-/native-metrics-2.1.1.tgz#2a7abd87373e46b3c957a08124a72c0c41968dc8"
+  dependencies:
+    nan "^2.4.0"
+
 accept@2.x.x:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/accept/-/accept-2.1.4.tgz#887af54ceee5c7f4430461971ec400c61d09acbb"
@@ -859,7 +865,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -951,10 +957,6 @@ is-resolvable@^1.0.0:
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1236,19 +1238,25 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
+nan@^2.4.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-newrelic@^1.28.1:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-1.40.0.tgz#2548df14c441ebfc9d3b8eb989d137f7b69a1d6f"
+newrelic@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-2.0.0.tgz#bf242323e2c51d992077f417d6f09ca118f4ab69"
   dependencies:
     concat-stream "^1.5.0"
     https-proxy-agent "^0.3.5"
     json-stringify-safe "^5.0.0"
-    readable-stream "^1.1.13"
+    readable-stream "^2.1.4"
     semver "^5.3.0"
+  optionalDependencies:
+    "@newrelic/native-metrics" "^2.1.0"
 
 nigel@2.x.x:
   version "2.0.2"
@@ -1457,16 +1465,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^1.1.13:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^2.2.2:
+readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -1657,10 +1656,6 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR fixes how we load New Relic so that it actually works (ref #28). It is implemented similarly to how we did it in https://github.com/18F/federalist/pull/1021.

- Load `NEW_RELIC_LICENSE_KEY` from cloud.gov user-provided service
- Update README.md with new info
- Upgrade newrelic npm depedency

To Do:
- [x] setup UPS to store new relic key in both `staging` and `production` spaces.
  - [x] staging: `federalist-builder-env`
  - [x] prod: `federalist-builder-env`
