### PR TITLE
Fix deployment from Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,9 @@ jobs:
     docker:
       - image: circleci/node:6.11
         environment:
-          YARN_VERSION: 0.24.6-1
           CC_TEST_REPORTER_ID: 4c0674ab7fa1efa186ac5998f89136640d924fabcc0b99ed764bd9fc85043b97
     steps:
       - checkout
-      - run:
-          name: Install yarn
-          command: |
-            sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-            echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq yarn=$YARN_VERSION
       - run:
           name: Install codeclimate reporter
           command: |
@@ -41,15 +33,5 @@ jobs:
           name: Report test coverage
           command: ./cc-test-reporter after-build --exit-code $? < coverage/lcov.info
       - deploy:
-          name: Deploy to staging if on staging branch
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "staging" ]; then
-              ./scripts/deploy-circle.sh
-            fi
-      - deploy:
-          name: Deploy to master if on master branch
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./scripts/deploy-circle.sh
-            fi
-
+          name: Deploy to cloud.gov
+          command: ./scripts/deploy-circle.sh

--- a/scripts/deploy-circle.sh
+++ b/scripts/deploy-circle.sh
@@ -15,15 +15,20 @@ elif [ "$CIRCLE_BRANCH" == "staging" ]; then
   CF_APP="federalist-builder-staging"
   CF_MANIFEST="staging_manifest.yml"
 else
+  echo "Not on master or staging branch. Skipping deployment."
   exit
 fi
 
 CF_API=https://api.fr.cloud.gov
 CF_ORGANIZATION=gsa-18f-federalist
 
-wget https://s3.amazonaws.com/go-cli/releases/v6.23.1/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb
+# install cf cli
+curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+sudo dpkg -i cf-cli_amd64.deb
+rm cf-cli_amd64.deb
 
-rm temp.deb
+# install autopilot
+cf install-plugin autopilot -f -r CF-Community
 
 cf api $CF_API
 cf login -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION -s $CF_SPACE


### PR DESCRIPTION
Fixes broken deployment step from PR #46.

Also remove the custom `yarn` installation because it wasn't actually working and the `node` container from Circle has an up-to-date `yarn` install already.