### PR TITLE
Don't fail on cc-test-reporter after-build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
           command: yarn test
       - run:
           name: Report test coverage
-          command: ./cc-test-reporter after-build --exit-code $? < coverage/lcov.info
+          # Attempt to submit coverage. Use `|| true` to always succeed even if that submission fails.
+          command: ./cc-test-reporter after-build --exit-code $? < coverage/lcov.info || true
       - deploy:
           name: Deploy to cloud.gov
           command: ./scripts/deploy-circle.sh


### PR DESCRIPTION
Adds `|| true` to the codeclimate after-build submission. 

That command will fail if a report already exists for a given commit (which is kinda silly, IMO), which means builds cannot be successfully re-run (like if we wanted to rebuild to trigger a re-deployment of a known working version). Using `|| true` will make that command always succeed. We have it setup that way in `federalist` already.

