### PR TITLE
add healthcheck endpoint for monitoring builder health

### DIFF
--- a/test/cloud-foundry-auth-client-test.js
+++ b/test/cloud-foundry-auth-client-test.js
@@ -1,10 +1,14 @@
 const expect = require('chai').expect;
 const jwt = require('jsonwebtoken');
 const nock = require('nock');
+
 const CloudFoundryAuthClient = require('../src/cloud-foundry-auth-client');
 const mockTokenRequest = require('./nocks/cloud-foundry-oauth-token-nock');
 
-const mockToken = (expiration = (Date.now() / 1000) + 600) => jwt.sign({ exp: expiration }, '123abc');
+const mockToken = (expiration = (Date.now() / 1000) + 600) => (
+  jwt.sign({ exp: expiration }, '123abc')
+);
+
 
 describe('CloudFoundryAuthClient', () => {
   describe('.accessToken()', () => {

--- a/test/nocks/cloud-foundry-oauth-token-nock.js
+++ b/test/nocks/cloud-foundry-oauth-token-nock.js
@@ -4,7 +4,7 @@ const nock = require('nock');
 const mockTokenRequest = (token) => {
   const accessToken = token || jwt.sign({ exp: (Date.now() / 1000) + 600 }, '123abc');
 
-  return nock('https://login.example.com', {
+  const n = nock('https://login.example.com', {
     reqheaders: {
       authorization: `Basic ${Buffer('cf:').toString('Base64')}`,
     },
@@ -13,7 +13,13 @@ const mockTokenRequest = (token) => {
     username: 'deploy_user',
     password: 'deploy_pass',
     response_type: 'token',
-  }).reply(200, {
+  });
+
+  if (token === 'badtoken') {
+    return n.reply(401);
+  }
+
+  return n.reply(200, {
     access_token: accessToken,
   });
 };


### PR DESCRIPTION
Right now, it only checks to make sure that the builder is able
to authenticate with cloud.gov. Other checks can be added in the
future.

Post-merge:
- [ ] add a "synthetics" check to New Relic that makes sure the response contains `"ok": true`