### PR TITLE
Fetch attributes from SQS queue in healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "aws-sdk-mock": "^1.7.0",
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",

--- a/src/sqs-client.js
+++ b/src/sqs-client.js
@@ -7,18 +7,16 @@ class SQSClient {
     this._sqs = new AWS.SQS();
   }
 
-  getQueueAttributes(/** attribute1, attribute2 ...n*/) {
-    const args = [].slice.call(arguments);
-
-    return new Promise((resolve, reject) => {
+  getQueueAttributes(...attributes) {
+    return new Promise((resolve) => {
       this._sqs.getQueueAttributes(
-        this._queueAttributesParams(args),
+        this._queueAttributesParams(...attributes),
         (error, data) => {
           let output;
 
           if (!error) {
             output = data.Attributes;
-           } else {
+          } else {
             output = { error: QUEUE_ATTRIBUTES_FALLBACK };
           }
 
@@ -63,7 +61,7 @@ class SQSClient {
   _queueAttributesParams(attributes) {
     return {
       QueueUrl: this._sqsQueueURL(),
-      AttributeNames: [...attributes]
+      AttributeNames: [...attributes],
     };
   }
 

--- a/test/aws-mock.js
+++ b/test/aws-mock.js
@@ -1,0 +1,13 @@
+const AWS = require('aws-sdk-mock');
+
+module.exports = {
+  mock(service, method, data, error = null) {
+    AWS.mock(service, method, (params, callback) => {
+      callback(error, data);
+    });
+
+    return () => {
+      AWS.restore(service, method);
+    };
+  }
+};

--- a/test/aws-mock.js
+++ b/test/aws-mock.js
@@ -9,5 +9,5 @@ module.exports = {
     return () => {
       AWS.restore(service, method);
     };
-  }
+  },
 };

--- a/test/aws-mock.js
+++ b/test/aws-mock.js
@@ -1,4 +1,7 @@
 const AWS = require('aws-sdk-mock');
+const AWS_SDK = require('aws-sdk');
+
+AWS.setSDKInstance(AWS_SDK);
 
 module.exports = {
   mock(service, method, data, error = null) {

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -57,7 +57,7 @@ describe('server', () => {
       });
     });
 
-    it('should not be ok if SQS attributes cannot be retreived', (done) => {
+    it('should not be ok if SQS attributes cannot be retrieved', (done) => {
       const error = { error: 'queue attributes unavailable' };
       const restoreAWS = awsMock.mock('SQS', 'getQueueAttributes', null, error);
       const testServer = server(mockCluster());

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -34,8 +34,10 @@ describe('server', () => {
         method: 'GET',
         url: '/healthcheck',
       }, (response) => {
+        const expected = Object.assign({}, { ok: true }, queueAttributes.Attributes);
+
         expect(response.statusCode).to.eq(200);
-        expect(response.result).to.deep.equal(Object.assign({}, { ok: true }, queueAttributes.Attributes));
+        expect(response.result).to.deep.equal(expected);
         restoreAWS();
         done();
       });

--- a/test/sqs-client-test.js
+++ b/test/sqs-client-test.js
@@ -22,6 +22,13 @@ describe('SQSClient', () => {
     return () => { sqsClient._sqs[method] = safeMethod; };
   };
 
+  const providesQueueUrl = (method, done) => {
+    sqsClient._sqs[method] = (params) => {
+      expect(params.QueueUrl).to.equal(process.env.SQS_URL);
+      done();
+    };
+  };
+
   describe('.receiveMessage()', () => {
     let receiveMessageStub;
 
@@ -72,11 +79,7 @@ describe('SQSClient', () => {
     });
 
     it('should call SQS.ReceiveMessage with the correct queue URL', (done) => {
-      sqsClient._sqs.receiveMessage = (params) => {
-        expect(params.QueueUrl).to.equal(process.env.SQS_URL);
-        done();
-      };
-
+      providesQueueUrl('receiveMessage', done);
       sqsClient.receiveMessage({});
     });
   });
@@ -107,22 +110,14 @@ describe('SQSClient', () => {
     });
 
     it('should call SQS.DeleteMessage with the correct queue URL', (done) => {
-      sqsClient._sqs.deleteMessage = (params) => {
-        expect(params.QueueUrl).to.equal(process.env.SQS_URL);
-        done();
-      };
-
+      providesQueueUrl('deleteMessage', done);
       sqsClient.deleteMessage({});
     });
   });
 
   describe('.getQueueAttributes', () => {
     it('calls function with the correct queue url', (done) => {
-      sqsClient._sqs.getQueueAttributes = (params) => {
-        expect(params.QueueUrl).to.equal(process.env.SQS_URL);
-        done();
-      };
-
+      providesQueueUrl('getQueueAttributes', done);
       sqsClient.getQueueAttributes('ApproximateNumberOfMessages');
     });
 

--- a/test/sqs-client-test.js
+++ b/test/sqs-client-test.js
@@ -100,7 +100,7 @@ describe('SQSClient', () => {
     });
   });
 
-  describe('.getQueueAttributes', (done) => {
+  describe('.getQueueAttributes', () => {
     it('calls function with the correct queue url', (done) => {
       sqsClient._sqs.getQueueAttributes = (params) => {
         expect(params.QueueUrl).to.equal(process.env.SQS_URL);
@@ -115,7 +115,7 @@ describe('SQSClient', () => {
         callback(true);
       };
 
-      sqsClient.getQueueAttributes().then((response) => {
+      sqsClient.getQueueAttributes('').then((response) => {
         expect(response).to.deep.equal({ error: 'queue attributes unavailable' });
         done();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,14 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+aws-sdk-mock@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-1.7.0.tgz#7698b3ba82f493f71ff060ae2123cd0806ad8676"
+  dependencies:
+    aws-sdk "^2.3.0"
+    sinon "^1.17.3"
+    traverse "^0.6.6"
+
 aws-sdk@^2.2.10:
   version "2.82.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.82.0.tgz#a94cfe90c15ee0e403f00f0665dccb98aa93e1f8"
@@ -181,6 +189,20 @@ aws-sdk@^2.2.10:
     sax "1.2.1"
     url "0.10.3"
     uuid "3.0.1"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
+
+aws-sdk@^2.3.0:
+  version "2.196.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.196.0.tgz#0fabf9b1d22997c59d77a025c6bd4666924f147c"
+  dependencies:
+    buffer "4.9.1"
+    events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
 
@@ -972,6 +994,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+events@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -1126,6 +1152,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1356,6 +1388,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -1867,6 +1903,10 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
 lodash@~4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.9.0.tgz#4c20d742f03ce85dc700e0dd7ab9bcab85e6fc14"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2551,6 +2591,14 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
+samsam@~1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+
 sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -2591,6 +2639,15 @@ shot@^3.4.2:
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^1.17.3:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -2836,6 +2893,10 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -2906,11 +2967,17 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
+
 uuid@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@^3.0.0:
+uuid@3.1.0, uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
I think there are a couple of opportunities for refactoring in the future (or now?):

* Break out the reply logic into a separate response class
* Break out the health check so we can inject it's dependencies — this will let us mock them more easily; obviating the need, for example, the `aws-mocks` library