### PR TITLE
Make some updates to queueAttributes and fix overly-destructured param.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,9 @@
 ---
 engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - test/
   eslint:
     enabled: true
     channel: "eslint-3"

--- a/src/server.js
+++ b/src/server.js
@@ -33,7 +33,7 @@ function createServer(cluster) {
       // Array of promises returned from methods we want included in the healthcheck
       const checkPromises = [
         authClient.accessToken(), // make sure we can authenticate with cloud.gov
-        queueClient.getQueueAttributes(NUM_MESSAGES),
+        queueClient.getQueueAttributes([NUM_MESSAGES]),
       ];
 
       const replyOk = (attributes = {}) => reply(Object.assign({}, { ok: true }, attributes));

--- a/src/sqs-client.js
+++ b/src/sqs-client.js
@@ -7,10 +7,12 @@ class SQSClient {
     this._sqs = new AWS.SQS();
   }
 
-  getQueueAttributes(...attributes) {
+  getQueueAttributes(attributesArray) {
+    // attributesArray should be an array of SQS attribute names
+    // ref: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html
     return new Promise((resolve) => {
       this._sqs.getQueueAttributes(
-        this._queueAttributesParams(...attributes),
+        this._queueAttributesParams(attributesArray),
         (error, data) => {
           let output;
 
@@ -58,10 +60,10 @@ class SQSClient {
     });
   }
 
-  _queueAttributesParams(attributes) {
+  _queueAttributesParams(attributesArray) {
     return {
       QueueUrl: this._sqsQueueURL(),
-      AttributeNames: [...attributes],
+      AttributeNames: attributesArray,
     };
   }
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -23,7 +23,7 @@ describe('server', () => {
 
   describe('GET /healthcheck', () => {
     it('should be ok when a valid access token can be retrieved', (done) => {
-      const queueAttributes = { Attributes: { ApproximateNumberOfMessage: 2 } };
+      const queueAttributes = { Attributes: { ApproximateNumberOfMessages: 2 } };
       const restoreAWS = awsMock.mock('SQS', 'getQueueAttributes', queueAttributes);
 
       const testServer = server(mockCluster());
@@ -34,7 +34,10 @@ describe('server', () => {
         method: 'GET',
         url: '/healthcheck',
       }, (response) => {
-        const expected = Object.assign({}, { ok: true }, queueAttributes.Attributes);
+        const expected = {
+          ok: true,
+          queueAttributes: queueAttributes.Attributes,
+        };
 
         expect(response.statusCode).to.eq(200);
         expect(response.result).to.deep.equal(expected);

--- a/test/sqs-client-test.js
+++ b/test/sqs-client-test.js
@@ -116,9 +116,18 @@ describe('SQSClient', () => {
   });
 
   describe('.getQueueAttributes', () => {
+    it('calls SQS.getQueueAttributes with the requested attributes', (done) => {
+      sqsClient._sqs.getQueueAttributes = (params) => {
+        expect(params.AttributeNames).to.deep.equal(['aa', 'bb', 'cc']);
+        done();
+      };
+
+      sqsClient.getQueueAttributes(['aa', 'bb', 'cc']);
+    });
+
     it('calls function with the correct queue url', (done) => {
       providesQueueUrl('getQueueAttributes', done);
-      sqsClient.getQueueAttributes('ApproximateNumberOfMessages');
+      sqsClient.getQueueAttributes(['ApproximateNumberOfMessages']);
     });
 
     it('returns an error object when SQS is unavailable', (done) => {
@@ -126,7 +135,7 @@ describe('SQSClient', () => {
         callback(true);
       };
 
-      sqsClient.getQueueAttributes('').then((response) => {
+      sqsClient.getQueueAttributes(['boop']).then((response) => {
         expect(response).to.deep.equal({ error: 'queue attributes unavailable' });
         done();
       });
@@ -139,7 +148,7 @@ describe('SQSClient', () => {
         callback(false, expected);
       };
 
-      sqsClient.getQueueAttributes('ApproximateNumberOfMessages').then((response) => {
+      sqsClient.getQueueAttributes(['ApproximateNumberOfMessages']).then((response) => {
         expect(response).to.deep.equal(expected.Attributes);
         done();
       });


### PR DESCRIPTION
Actually, remove destructuring completely and instead explicitly use an array of attribute names. 

Also:
- Rename variables and add supporting comments.
- Add an additional test to make sure params are set correctly.
- Nest the queueAttributes in a sub-object, and also add the `ApproximateNumberOfMessagesDelayed` attribute. See screenshot.
- Disable CodeClimate's duplication engine on the `test/` directory.

Even after getting the permissions on the SQS queues properly set, we had a bug that the requested SQS `attributes` parameter was getting destructured too much, so we were asking for an array of attributes that looked like `['A','p','p','r','o','x','i','m','a','t','e' ... ]`

<img width="387" alt="screen shot 2018-02-22 at 9 38 25 am" src="https://user-images.githubusercontent.com/697848/36547786-450246e4-17b4-11e8-8864-fb529073afce.png">
