### PR TITLE
Access CF Space GUID from user provided service

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Additional configuration is set up through environment variables:
 - `BUILD_TIMEOUT_SECONDS`: (required) number of seconds to let a build run before timing out
 - `BUILD_COMPLETE_CALLBACK_HOST` (required) the host that a build container should callback to when finished, e.g. `https://federalist-builder.18f.gov`
 - `BUILD_CONTAINER_DOCKER_IMAGE_NAME` (required) the name of the docker image that is used to run builds
-- `BUILD_SPACE_GUID` (required) the guid for the cloud.gov space where the build containers are located
 - `CLOUD_FOUNDRY_API_HOST` (required) the host for the Cloud Foundry API endpoint, e.g. `https://api.fr.cloud.gov`
 - `CLOUD_FOUNDRY_OAUTH_TOKEN_URL` (required) the OAuth2 token URL for Cloud Foundry, e.g. `https://login.fr.cloud.gov`
 - `DEPLOY_USER_USERNAME` (required) the username for the deploy user that starts builds in cloud.gov.

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,13 +13,13 @@ services:
 - credentials-rotator-user
 - ci-deploy-federalist-builder-user
 - ci-deploy-federalist-user
+- federalist-production-space
 env:
   NEW_RELIC_APP_NAME: "federalist-builder-prod"
   BUILD_TIMEOUT_SECONDS: 2700 # 45 * 60 seconds = 45 minutes
   SQS_URL: "https://sqs.us-east-1.amazonaws.com/144433228153/federalist-builds"
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder.fr.cloud.gov"
   BUILD_CONTAINER_DOCKER_IMAGE_NAME: "federalist-registry.fr.cloud.gov/federalist-garden-build"
-  BUILD_SPACE_GUID: "a1e19bd4-5066-40a7-8d53-fc9644c27e8e"
   CLOUD_FOUNDRY_API_HOST: "https://api.fr.cloud.gov"
   CLOUD_FOUNDRY_OAUTH_TOKEN_URL: "https://login.fr.cloud.gov/oauth/token"
   EXPECTED_NUM_BUILD_CONTAINERS: 6

--- a/src/cloud-foundry-api-client.js
+++ b/src/cloud-foundry-api-client.js
@@ -1,5 +1,6 @@
 const request = require('request');
 const url = require('url');
+const cfenv = require('cfenv');
 const CloudFoundryAuthClient = require('./cloud-foundry-auth-client');
 
 const STATE_STARTED = 'STARTED';
@@ -166,7 +167,14 @@ class CloudFoundryAPIClient {
   }
 
   _spaceGUID() {
-    return process.env.BUILD_SPACE_GUID;
+    const appEnv = cfenv.getAppEnv();
+    const cfSpaceGuid = appEnv.getServiceCreds(`federalist-${process.env.APP_ENV}-space`);
+
+    if (cfSpaceGuid) {
+      return cfSpaceGuid.guid;
+    }
+
+    return process.env.CF_SPACE_GUID;
   }
 }
 

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -13,12 +13,12 @@ services:
 - credentials-rotator-user
 - ci-deploy-federalist-builder-user
 - ci-deploy-federalist-user
+- federalist-staging-space
 env:
   NEW_RELIC_APP_NAME: "federalist-builder-staging"
   BUILD_TIMEOUT_SECONDS: 2700 # 45 * 60 seconds = 45 minutes
   BUILD_COMPLETE_CALLBACK_HOST: "https://federalist-builder-staging.fr.cloud.gov"
   BUILD_CONTAINER_DOCKER_IMAGE_NAME: "federalist-registry-staging.fr.cloud.gov/federalist-garden-build"
-  BUILD_SPACE_GUID: "af7be42d-47d6-4b4d-a15a-7098c7695c43"
   CLOUD_FOUNDRY_API_HOST: "https://api.fr.cloud.gov"
   CLOUD_FOUNDRY_OAUTH_TOKEN_URL: "https://login.fr.cloud.gov/oauth/token"
   LOG_LEVEL: "verbose"

--- a/test/env.js
+++ b/test/env.js
@@ -3,7 +3,7 @@ process.env.SQS_URL = 'https://sqs.us-east-1.amazonaws.com/123abc/456def';
 
 // Cloud Foundry API
 process.env.CLOUD_FOUNDRY_API_HOST = 'https://api.example.com';
-process.env.BUILD_SPACE_GUID = '123abc-456def-789ghi';
+process.env.CF_SPACE_GUID = '123abc-456def-789ghi';
 
 // Cloud Foundry Auth
 process.env.CLOUD_FOUNDRY_OAUTH_TOKEN_URL = 'https://login.example.com/oauth/token';


### PR DESCRIPTION
## Description

Uses a CF user provided service to access the CF Space GUID which is needed to make requests to the CF REST API

## Implementation

- [x] Create `federalist-<APP_ENV>-space` service to access the space guid
  - [x] Created in staging
  - [x] Created in production
- [x] Binds the service to the manifests
  - [x] Binds to staging
  - [x] Binds to production
- [x] Use `cfenv` module to retrieve the service's guid