### PR TITLE
Add queue client for bull

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
             else
               echo "export CF_SPACE=staging" >> $BASH_ENV
               echo "export CF_USERNAME=$CF_USERNAME_STAGING" >> $BASH_ENV
-              echo "export CF_PASSWORD=$CF_PASSWORD_STAGING" >> $BASH_ENV  
+              echo "export CF_PASSWORD=$CF_PASSWORD_STAGING" >> $BASH_ENV
             fi
 
       - run:
@@ -88,6 +88,10 @@ jobs:
       - image: circleci/node:14.15.0
         environment:
           CC_TEST_REPORTER_ID: 4c0674ab7fa1efa186ac5998f89136640d924fabcc0b99ed764bd9fc85043b97
+      - image: circleci/redis
+        environment:
+          REDIS_PORT: 6379
+          REDIS_HOST: redis
     steps:
       - checkout
       - run:
@@ -122,14 +126,14 @@ jobs:
       - image: cimg/base:2020.01
     parameters:
       app:
-        type: string      
+        type: string
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
 
       - deploy-to-cg:
-          app: << parameters.app >>          
+          app: << parameters.app >>
 
   restage:
     docker:
@@ -192,4 +196,4 @@ workflows:
           app: federalist-builder-staging
           filters:
             branches:
-              only: staging      
+              only: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
       - image: circleci/redis
         environment:
           REDIS_PORT: 6379
-          REDIS_HOST: redis
     steps:
       - checkout
       - run:

--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -9,6 +9,7 @@ applications:
     services:
       - federalist-((env))-sqs-creds
       - federalist-deploy-user
+      - federalist-((env))-redis
     env:
       TASK_MEM_GB: 2
       TASK_DISK_GB: 4

--- a/.env-sample.json
+++ b/.env-sample.json
@@ -4,6 +4,18 @@
     "space_name": "local"
   },
   "services": {
+    "aws-elasticache-redis": [
+      {
+        "name": "federalist-local-redis",
+        "credentials": {
+          "host": "<REDIS HOSTNAME>",
+          "hostname": "<REDIS HOSTNAME>",
+          "password": "<REDIS PASSWORD>",
+          "port": "<REDIS PORT>",
+          "uri": "<REDIS URI>"
+        }
+      }
+    ],
     "user-provided": [
       {
         "name": "federalist-local-sqs-creds",

--- a/.env-sample.json
+++ b/.env-sample.json
@@ -8,10 +8,6 @@
       {
         "name": "federalist-local-redis",
         "credentials": {
-          "host": "<REDIS HOSTNAME>",
-          "hostname": "<REDIS HOSTNAME>",
-          "password": "<REDIS PASSWORD>",
-          "port": "<REDIS PORT>",
           "uri": "<REDIS URI>"
         }
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:14.15
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ yarn
 yarn test
 ```
 
+### Using docker to test locally
+
+Since `federalist-builder` has tightly coupled build process, a dependence on the Cloud Foundry platform, and third party services, running tests locally with `docker-compose` can make the development experience a bit simpler.
+
+To build the containers run:
+`$ docker-compose build`
+
+To install the dependencies run:
+`$ docker-compose run app yarn`
+
+To test the builder run:
+`$ docker-compose run app yarn test`
+
+
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const BuildScheduler = require('./src/build-scheduler');
 const logger = require('./src/logger');
 const createServer = require('./src/server');
 const SQSClient = require('./src/sqs-client');
+const QueueClient = require('./src/queue-client');
 const BuilderPool = require('./src/cf-task-pool');
 
 const {
@@ -17,12 +18,14 @@ if (NEW_RELIC_APP_NAME && NEW_RELIC_LICENSE_KEY) {
 }
 
 const builderPool = new BuilderPool(appEnv);
-const buildQueue = new SQSClient(new AWS.SQS(), appEnv.sqsUrl);
+const buildSQSQueue = new SQSClient(new AWS.SQS(), appEnv.sqsUrl);
+const buildBullQueue = new QueueClient(appEnv.queueName);
 const server = createServer(builderPool, buildQueue);
 
 const buildScheduler = new BuildScheduler(
   builderPool,
-  buildQueue,
+  buildSQSQueue,
+  buildBullQueue,
   server
 );
 

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ if (NEW_RELIC_APP_NAME && NEW_RELIC_LICENSE_KEY) {
 const builderPool = new BuilderPool(appEnv);
 const buildSQSQueue = new SQSClient(new AWS.SQS(), appEnv.sqsUrl);
 const buildBullQueue = new QueueClient(appEnv.queueName);
-const server = createServer(builderPool, buildQueue);
+const server = createServer(builderPool, buildSQSQueue);
 
 const buildScheduler = new BuildScheduler(
   builderPool,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  app:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    command: ["yarn", "dev"]
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+    ports:
+      - 8000:8000
+    environment:
+      PORT: 8000
+      REDIS_HOST: redis
+  redis:
+    image: redis
+    ports:
+      - 6379:6379

--- a/env.js
+++ b/env.js
@@ -1,6 +1,7 @@
 const cfenv = require('cfenv');
 
 const {
+  CIRCLECI,
   CLOUD_FOUNDRY_OAUTH_TOKEN_URL,
   NODE_ENV,
   TASK_DISK_GB,
@@ -29,8 +30,11 @@ appEnv.cloudFoundryCreds = {
 appEnv.cloudFoundryApiHost = cfApiHost;
 
 appEnv.queueName = `federalist-${spaceName}-queue`;
-appEnv.redisCreds = redisCreds;
-appEnv.redisUrl = redisCreds.uri;
+if (CIRCLECI) {
+  appEnv.redisUrl = 'redis://localhost:6379';
+} else {
+  appEnv.redisUrl = redisCreds.uri;
+}
 appEnv.sqsCreds = sqsCreds;
 appEnv.sqsUrl = sqsCreds.sqs_url;
 

--- a/env.js
+++ b/env.js
@@ -35,6 +35,13 @@ if (CIRCLECI) {
 } else {
   appEnv.redisUrl = redisCreds.uri;
 }
+
+if (spaceName === 'staging' || spaceName === 'production') {
+  appEnv.redisTls = {};
+} else {
+  appEnv.redisTls = null;
+}
+
 appEnv.sqsCreds = sqsCreds;
 appEnv.sqsUrl = sqsCreds.sqs_url;
 

--- a/env.js
+++ b/env.js
@@ -18,6 +18,7 @@ const { cf_api: cfApiHost, space_name: spaceName } = appEnv.app;
 
 const cfCreds = appEnv.getServiceCreds('federalist-deploy-user');
 const sqsCreds = appEnv.getServiceCreds(`federalist-${spaceName}-sqs-creds`);
+const redisCreds = appEnv.getServiceCreds(`federalist-${spaceName}-redis`);
 
 // Some helpful attributes
 appEnv.cloudFoundryOAuthTokenUrl = CLOUD_FOUNDRY_OAUTH_TOKEN_URL;
@@ -27,6 +28,9 @@ appEnv.cloudFoundryCreds = {
 };
 appEnv.cloudFoundryApiHost = cfApiHost;
 
+appEnv.queueName = `federalist-${spaceName}-queue`;
+appEnv.redisCreds = redisCreds;
+appEnv.redisUrl = redisCreds.uri;
 appEnv.sqsCreds = sqsCreds;
 appEnv.sqsUrl = sqsCreds.sqs_url;
 

--- a/env.js
+++ b/env.js
@@ -29,7 +29,7 @@ appEnv.cloudFoundryCreds = {
 };
 appEnv.cloudFoundryApiHost = cfApiHost;
 
-appEnv.queueName = `federalist-${spaceName}-queue`;
+appEnv.queueName = 'site-build-queue';
 if (CIRCLECI) {
   appEnv.redisUrl = 'redis://localhost:6379';
 } else {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@hapi/hapi": "^20.0.3",
     "aws-sdk": "^2.820.0",
     "axios": "^0.21.1",
+    "bull": "^3.20.1",
     "cfenv": "^1.2.3",
     "jsonwebtoken": "^8.5.1",
     "newrelic": "^7.0.2",

--- a/src/build-scheduler.js
+++ b/src/build-scheduler.js
@@ -71,7 +71,7 @@ class BuildScheduler {
     logger.verbose('Starting build %s', build.federalistBuildId());
 
     return this._builderPool.startBuild(build)
-      .then(() => this._buildQueue.deleteMessage(build.sqsMessage));
+      .then(() => this._buildQueue.deleteMessage(build.queueMessage));
   }
 }
 

--- a/src/build-scheduler.js
+++ b/src/build-scheduler.js
@@ -21,7 +21,7 @@ class BuildScheduler {
   }
 
   _run() {
-    Promise.allSettled([
+    Promise.all([
       this._findAndScheduleNewBuild(this._bullQueue, true),
       this._findAndScheduleNewBuild(this._sqsQueue),
     ])

--- a/src/build-scheduler.js
+++ b/src/build-scheduler.js
@@ -2,9 +2,10 @@ const Build = require('./build');
 const logger = require('./logger');
 
 class BuildScheduler {
-  constructor(builderPool, buildQueue, server) {
+  constructor(builderPool, sqsQueue, bullQueue, server) {
     this._builderPool = builderPool;
-    this._buildQueue = buildQueue;
+    this._sqsQueue = sqsQueue;
+    this._bullQueue = bullQueue;
     this._server = server;
   }
 
@@ -20,7 +21,10 @@ class BuildScheduler {
   }
 
   _run() {
-    this._findAndScheduleNewBuild()
+    Promise.allSettled([
+      this._findAndScheduleNewBuild(this._bullQueue, true),
+      this._findAndScheduleNewBuild(this._sqsQueue),
+    ])
       .catch((error) => {
         logger.error(error);
       })
@@ -33,11 +37,11 @@ class BuildScheduler {
       });
   }
 
-  async _attemptToStartBuild(build) {
+  async _attemptToStartBuild(build, queue) {
     logger.verbose('Attempting to start build %s', build.federalistBuildId());
 
     if (await this._builderPool.canStartBuild(build)) {
-      return this._startBuildAndDeleteMessage(build);
+      return this._startBuildAndDeleteMessage(build, queue);
     }
 
     logger.info(
@@ -48,30 +52,30 @@ class BuildScheduler {
     return Promise.resolve(null);
   }
 
-  _findAndScheduleNewBuild() {
+  _findAndScheduleNewBuild(queue, isBullQueue = false) {
     logger.verbose('Waiting for message');
 
-    return this._buildQueue.receiveMessage()
+    return queue.receiveMessage()
       .then((message) => {
         if (message) {
           logger.verbose('Received message');
-          const build = new Build(message);
+          const build = new Build(message, isBullQueue);
           const owner = build.containerEnvironment.OWNER;
           const repo = build.containerEnvironment.REPOSITORY;
           const branch = build.containerEnvironment.BRANCH;
           logger.info('New build %s/%s/%s - %s', owner, repo, branch, build.federalistBuildId());
 
-          return this._attemptToStartBuild(build);
+          return this._attemptToStartBuild(build, queue);
         }
         return null;
       });
   }
 
-  _startBuildAndDeleteMessage(build) {
+  _startBuildAndDeleteMessage(build, queue) {
     logger.verbose('Starting build %s', build.federalistBuildId());
 
     return this._builderPool.startBuild(build)
-      .then(() => this._buildQueue.deleteMessage(build.queueMessage));
+      .then(() => queue.deleteMessage(build.queueMessage));
   }
 }
 

--- a/src/bull-queue.js
+++ b/src/bull-queue.js
@@ -1,9 +1,28 @@
 const Queue = require('bull');
 const appEnv = require('../env');
 
-const bullQueue = (queueName = appEnv.queueName) => {
+const bullQueue = (
+  queueName = appEnv.queueName,
+  {
+    createClient,
+    redis,
+    limiter,
+    prefix,
+    defaultJobOptions,
+    settings,
+  } = {}
+) => {
   const redisUrl = appEnv.redisUrl;
-  return new Queue(queueName, redisUrl);
+  const updatedSettings = { drainDelay: 20, ...settings };
+
+  return new Queue(queueName, redisUrl, {
+    createClient,
+    redis,
+    limiter,
+    prefix,
+    defaultJobOptions,
+    settings: updatedSettings,
+  });
 };
 
 module.exports = bullQueue;

--- a/src/bull-queue.js
+++ b/src/bull-queue.js
@@ -13,11 +13,12 @@ const bullQueue = (
   } = {}
 ) => {
   const redisUrl = appEnv.redisUrl;
+  const updatedRedis = { tls: appEnv.redisTls, ...redis };
   const updatedSettings = { drainDelay: 20, ...settings };
 
   return new Queue(queueName, redisUrl, {
     createClient,
-    redis,
+    redis: updatedRedis,
     limiter,
     prefix,
     defaultJobOptions,

--- a/src/bull-queue.js
+++ b/src/bull-queue.js
@@ -1,0 +1,9 @@
+const Queue = require('bull');
+const appEnv = require('../env');
+
+const bullQueue = (queueName = appEnv.queueName) => {
+  const redisUrl = appEnv.redisUrl;
+  return new Queue(queueName, redisUrl);
+};
+
+module.exports = bullQueue;

--- a/src/queue-client.js
+++ b/src/queue-client.js
@@ -2,9 +2,8 @@ const QUEUE_ATTRIBUTES_FALLBACK = 'Queue attributes unavailable.';
 const jobNotFound = id => `Job ${id} not found.`;
 
 class QueueClient {
-  constructor(bullQueue, queueTimeout = 5000) {
+  constructor(bullQueue) {
     this._queue = bullQueue;
-    this._queueTimeout = queueTimeout;
   }
 
   deleteMessage(message) {
@@ -31,9 +30,10 @@ class QueueClient {
   }
 
   receiveMessage() {
-    return new Promise((resolve) => {
-      setTimeout(() => resolve(undefined), this._queueTimeout);
-      this._queue.process((job) => {
+    return this._queue.getNextJob()
+      .then((job) => {
+        if (!job) return undefined;
+
         const {
           id,
           data,
@@ -42,15 +42,14 @@ class QueueClient {
           failedReason,
         } = job;
 
-        resolve({
+        return {
           id,
           data,
           timestamp,
           processedOn,
           failedReason,
-        });
+        };
       });
-    });
   }
 
   _queueAvailableAttributes(jobCounts, attributesArray) {

--- a/src/queue-client.js
+++ b/src/queue-client.js
@@ -1,0 +1,79 @@
+const QUEUE_ATTRIBUTES_FALLBACK = 'Queue attributes unavailable.';
+const jobNotFound = id => `Job ${id} not found.`;
+
+class QueueClient {
+  constructor(bullQueue, queueTimeout = 5000) {
+    this._queue = bullQueue;
+    this._queueTimeout = queueTimeout;
+  }
+
+  deleteMessage(message) {
+    const { id } = message;
+    return this._queue.getJob(id)
+      .then((job) => {
+        if (job === null) {
+          const error = jobNotFound(id);
+          throw new Error(error);
+        }
+
+        return job.remove();
+      })
+      .then(() => message);
+  }
+
+  getQueueAttributes(attributesArray = []) {
+    return this._queue.getJobCounts()
+      .then((jobCounts) => {
+        const output = this._queueAvailableAttributes(jobCounts, attributesArray);
+        return output;
+      })
+      .catch(() => ({ error: QUEUE_ATTRIBUTES_FALLBACK }));
+  }
+
+  receiveMessage() {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(undefined), this._queueTimeout);
+      this._queue.process((job) => {
+        const {
+          id,
+          data,
+          timestamp,
+          processedOn,
+          failedReason,
+        } = job;
+
+        resolve({
+          id,
+          data,
+          timestamp,
+          processedOn,
+          failedReason,
+        });
+      });
+    });
+  }
+
+  _queueAvailableAttributes(jobCounts, attributesArray) {
+    const output = {};
+    const availableAttributes = Object.keys(jobCounts)
+      .filter((key) => {
+        if (attributesArray.length === 0) {
+          return true;
+        }
+
+        return attributesArray.indexOf(key) !== -1;
+      });
+
+    if (availableAttributes.length === 0) {
+      throw new Error();
+    }
+
+    availableAttributes.map(attribute => Object.assign(
+      output, { [attribute]: jobCounts[attribute] }
+    ));
+
+    return output;
+  }
+}
+
+module.exports = QueueClient;

--- a/test/build-scheduler-test.js
+++ b/test/build-scheduler-test.js
@@ -20,11 +20,11 @@ const mockBuildSQSQueue = sqs => new SQSClient({
   ...sqs,
 });
 
-const mockedBullReceiveMessage = message => message;
+const mockedBullReceiveMessage = () => new Promise(resolve => resolve({}));
 const mockedBullDeleteMessage = () => new Promise(resolve => resolve({}));
 
 const mockBuildBullQueue = bull => new QueueClient({
-  process: mockedBullReceiveMessage,
+  getNextJob: mockedBullReceiveMessage,
   getJob: mockedBullDeleteMessage,
   ...bull,
 });
@@ -186,7 +186,7 @@ describe('BuildScheduler', () => {
       expect(runningBuildCount).to.equal(10);
       buildScheduler.stop();
       done();
-    }, 50);
+    }, 90);
   });
 
   it('should not delete the message if the build fails to start', (done) => {
@@ -215,7 +215,7 @@ describe('BuildScheduler', () => {
     };
 
     let hasReceivedBullMessage = false;
-    bull.process = () => new Promise((resolve) => {
+    bull.getNextJob = () => new Promise((resolve) => {
       if (!hasReceivedBullMessage) {
         hasReceivedBullMessage = true;
         resolve({

--- a/test/build-test.js
+++ b/test/build-test.js
@@ -12,6 +12,17 @@ const sqsMessage = {
   }),
 };
 
+const bullMessage = {
+  data: {
+    environment: [
+      { name: 'OVERRIDE_A', value: 'VALUE A' },
+      { name: 'OVERRIDE_B', value: 'VALUE B' },
+      { name: 'OVERRIDE_C', value: 'VALUE C' },
+    ],
+    name: 'Conatiner Name',
+  },
+};
+
 describe('Build', () => {
   describe('constructor', () => {
     it('should set a buildID', () => {
@@ -19,19 +30,37 @@ describe('Build', () => {
       expect(build.buildID).to.be.a('string');
     });
 
-    it('should set the container environment from an SQS message', () => {
-      const build = new Build(sqsMessage);
-      expect(build.containerEnvironment).to.have.property('OVERRIDE_A', 'VALUE A');
-      expect(build.containerEnvironment).to.have.property('OVERRIDE_B', 'VALUE B');
-      expect(build.containerEnvironment).to.have.property('OVERRIDE_C', 'VALUE C');
-    });
+    describe('SQS Queue', () => {
+      it('should set the container environment from a queue message', () => {
+        const build = new Build(sqsMessage);
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_A', 'VALUE A');
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_B', 'VALUE B');
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_C', 'VALUE C');
+      });
 
-    it('should add the FEDERALIST_BUILDER_CALLBACK to the container environment', () => {
-      const build = new Build(sqsMessage);
-      expect(build.containerEnvironment).to.have.property(
-        'FEDERALIST_BUILDER_CALLBACK',
-        `http://localhost:3000/builds/${build.buildID}/callback`
-      );
+      it('should add the FEDERALIST_BUILDER_CALLBACK to the container environment', () => {
+        const build = new Build(sqsMessage);
+        expect(build.containerEnvironment).to.have.property(
+          'FEDERALIST_BUILDER_CALLBACK',
+          `http://localhost:3000/builds/${build.buildID}/callback`
+        );
+      });
+    });
+    describe('Bull Queue', () => {
+      it('should set the container environment from a queue message', () => {
+        const build = new Build(bullMessage, true);
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_A', 'VALUE A');
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_B', 'VALUE B');
+        expect(build.containerEnvironment).to.have.property('OVERRIDE_C', 'VALUE C');
+      });
+
+      it('should add the FEDERALIST_BUILDER_CALLBACK to the container environment', () => {
+        const build = new Build(bullMessage, true);
+        expect(build.containerEnvironment).to.have.property(
+          'FEDERALIST_BUILDER_CALLBACK',
+          `http://localhost:3000/builds/${build.buildID}/callback`
+        );
+      });
     });
   });
 });

--- a/test/env.json
+++ b/test/env.json
@@ -8,10 +8,6 @@
       {
         "name": "federalist-test-redis",
         "credentials": {
-          "host": "redis",
-          "hostname": "redis",
-          "password": "password",
-          "port": "6379",
           "uri": "redis://redis:6379"
         }
       }

--- a/test/env.json
+++ b/test/env.json
@@ -4,6 +4,18 @@
     "space_name": "test"
   },
   "services": {
+    "aws-elasticache-redis": [
+      {
+        "name": "federalist-test-redis",
+        "credentials": {
+          "host": "redis",
+          "hostname": "redis",
+          "password": "password",
+          "port": "6379",
+          "uri": "redis://redis:6379"
+        }
+      }
+    ],
     "user-provided": [
       {
         "name": "federalist-test-sqs-creds",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,21 @@
+const bullQueue = require('../src/bull-queue');
+
+const testAddJobsToQueue = (queueName, jobData, testMethod) => {
+  const testQueue = bullQueue(queueName);
+  return testQueue.addBulk(jobData)
+    .then(() => testMethod(testQueue))
+    .then(() => testQueue.empty())
+    .then(() => testQueue.close());
+};
+
+const testEmptyQueue = (queueName, testMethod) => {
+  const testQueue = bullQueue(queueName);
+  return testMethod(testQueue)
+    .then(() => testQueue.empty())
+    .then(() => testQueue.close());
+};
+
+module.exports = {
+  testAddJobsToQueue,
+  testEmptyQueue,
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@ const testAddJobsToQueue = (queueName, jobData, testMethod) => {
 };
 
 const testEmptyQueue = (queueName, testMethod) => {
-  const testQueue = bullQueue(queueName);
+  const testQueue = bullQueue(queueName, { settings: { drainDelay: 1 } });
   return testMethod(testQueue)
     .then(() => testQueue.empty())
     .then(() => testQueue.close());

--- a/test/queue-client-test.js
+++ b/test/queue-client-test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
-const bullQueue = require('../src/bull-queue');
 const QueueClient = require('../src/queue-client');
+const { testAddJobsToQueue, testEmptyQueue } = require('./helpers');
 
 const jobKeys = [
   'id',
@@ -14,21 +14,6 @@ const mockQueue = (queue, output) => ({
   getJobCounts: () => new Promise(resolve => resolve(output)),
   ...queue,
 });
-
-const addJobsToQueue = (queueName, jobData, testMethod) => {
-  const testQueue = bullQueue(queueName);
-  return testQueue.addBulk(jobData)
-    .then(() => testMethod(testQueue))
-    .then(() => testQueue.empty())
-    .then(() => testQueue.close());
-};
-
-const createQueue = (queueName, testMethod) => {
-  const testQueue = bullQueue(queueName);
-  return testMethod(testQueue)
-    .then(() => testQueue.empty())
-    .then(() => testQueue.close());
-};
 
 describe('QueueClient', () => {
   describe('.receiveMessage()', () => {
@@ -46,7 +31,7 @@ describe('QueueClient', () => {
           });
       };
 
-      return addJobsToQueue(queueName, jobData, testMethod);
+      return testAddJobsToQueue(queueName, jobData, testMethod);
     });
 
     it('should receive a the FIFO message from the queue', () => {
@@ -67,7 +52,7 @@ describe('QueueClient', () => {
           });
       };
 
-      return addJobsToQueue(queueName, jobData, testMethod);
+      return testAddJobsToQueue(queueName, jobData, testMethod);
     });
 
     it('should respond with undefined if there are no messages after 1 second', () => {
@@ -80,7 +65,7 @@ describe('QueueClient', () => {
           });
       };
 
-      return createQueue(queueName, testMethod);
+      return testEmptyQueue(queueName, testMethod);
     });
   });
 
@@ -105,7 +90,7 @@ describe('QueueClient', () => {
           });
       };
 
-      return addJobsToQueue(queueName, jobData, testMethod);
+      return testAddJobsToQueue(queueName, jobData, testMethod);
     });
 
     it('should reject with an error if queue job does not exist', () => {
@@ -126,7 +111,7 @@ describe('QueueClient', () => {
           });
       };
 
-      return addJobsToQueue(queueName, jobData, testMethod);
+      return testAddJobsToQueue(queueName, jobData, testMethod);
     });
   });
 
@@ -250,7 +235,7 @@ describe('QueueClient', () => {
         });
       };
 
-      return addJobsToQueue(queueName, jobData, testMethod);
+      return testAddJobsToQueue(queueName, jobData, testMethod);
     });
   });
 });

--- a/test/queue-client-test.js
+++ b/test/queue-client-test.js
@@ -58,7 +58,7 @@ describe('QueueClient', () => {
     it('should respond with undefined if there are no messages after 1 second', () => {
       const queueName = 'no-messages';
       const testMethod = (queue) => {
-        const queueClient = new QueueClient(queue, 1000);
+        const queueClient = new QueueClient(queue);
         return queueClient.receiveMessage()
           .then((response) => {
             expect(response).to.deep.be.undefined;

--- a/test/queue-client-test.js
+++ b/test/queue-client-test.js
@@ -1,0 +1,256 @@
+const { expect } = require('chai');
+const bullQueue = require('../src/bull-queue');
+const QueueClient = require('../src/queue-client');
+
+const jobKeys = [
+  'id',
+  'data',
+  'timestamp',
+  'processedOn',
+  'failedReason',
+];
+
+const mockQueue = (queue, output) => ({
+  getJobCounts: () => new Promise(resolve => resolve(output)),
+  ...queue,
+});
+
+const addJobsToQueue = (queueName, jobData, testMethod) => {
+  const testQueue = bullQueue(queueName);
+  return testQueue.addBulk(jobData)
+    .then(() => testMethod(testQueue))
+    .then(() => testQueue.empty())
+    .then(() => testQueue.close());
+};
+
+const createQueue = (queueName, testMethod) => {
+  const testQueue = bullQueue(queueName);
+  return testMethod(testQueue)
+    .then(() => testQueue.empty())
+    .then(() => testQueue.close());
+};
+
+describe('QueueClient', () => {
+  describe('.receiveMessage()', () => {
+    it('should receive a message from the queue', () => {
+      const queueName = 'received-message';
+      const jobData = [{
+        data: { test: 'data', job_id: 1 },
+      }];
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+        return queueClient.receiveMessage()
+          .then((response) => {
+            expect(response).to.have.keys(jobKeys);
+            expect(response.data).to.deep.equal(jobData[0].data);
+          });
+      };
+
+      return addJobsToQueue(queueName, jobData, testMethod);
+    });
+
+    it('should receive a the FIFO message from the queue', () => {
+      const queueName = 'received-messages';
+      const jobData = [{
+        data: { test: 'a job', job_id: 1 },
+      }, {
+        data: { test: 'another job', job_id: 2 },
+      }, {
+        data: { test: 'another job again', job_id: 3 },
+      }];
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+        return queueClient.receiveMessage()
+          .then((response) => {
+            expect(response).to.have.keys(jobKeys);
+            expect(response.data).to.deep.equal(jobData[0].data);
+          });
+      };
+
+      return addJobsToQueue(queueName, jobData, testMethod);
+    });
+
+    it('should respond with undefined if there are no messages after 1 second', () => {
+      const queueName = 'no-messages';
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue, 1000);
+        return queueClient.receiveMessage()
+          .then((response) => {
+            expect(response).to.deep.be.undefined;
+          });
+      };
+
+      return createQueue(queueName, testMethod);
+    });
+  });
+
+  describe('.deleteMessage(message)', () => {
+    it('should delete queue job message', () => {
+      const queueName = 'delete-message-not-found';
+      const deleteJobId = 'my-delete-job';
+      const jobData = [{
+        data: { test: 'a job', job_id: 1 },
+      }, {
+        data: { test: 'another job', job_id: 2 },
+        opts: { jobId: deleteJobId },
+      }, {
+        data: { test: 'another job again', job_id: 3 },
+      }];
+      const message = { id: deleteJobId, ...jobData[1] };
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+        return queueClient.deleteMessage(message)
+          .then((response) => {
+            expect(response).to.deep.equal(message);
+          });
+      };
+
+      return addJobsToQueue(queueName, jobData, testMethod);
+    });
+
+    it('should reject with an error if queue job does not exist', () => {
+      const queueName = 'delete-message-not-found';
+      const notMessage = { id: 'not an id' };
+      const jobData = [{
+        data: { test: 'a job', job_id: 1 },
+      }, {
+        data: { test: 'another job', job_id: 2 },
+      }, {
+        data: { test: 'another job again', job_id: 3 },
+      }];
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+        return queueClient.deleteMessage(notMessage)
+          .catch((err) => {
+            expect(err).to.be.an('error');
+          });
+      };
+
+      return addJobsToQueue(queueName, jobData, testMethod);
+    });
+  });
+
+  describe('.getQueueAttributes', () => {
+    it('returns an error object when Queue is unavailable', () => {
+      const queueClient = new QueueClient(
+        mockQueue({ getJobCounts: () => new Promise((_, reject) => reject()) })
+      );
+
+      return queueClient.getQueueAttributes().then((response) => {
+        expect(response).to.deep.equal({ error: 'Queue attributes unavailable.' });
+      });
+    });
+
+    it('returns an error object when attributes are unavailable in response', () => {
+      const unavailableAttributes = ['not-an-option', 'alsobad'];
+      const allAttributes = {
+        waiting: 1,
+        active: 10,
+      };
+
+      const queueClient = new QueueClient(
+        mockQueue({}, allAttributes)
+      );
+
+      return queueClient.getQueueAttributes(unavailableAttributes).then((response) => {
+        expect(response).to.deep.equal({ error: 'Queue attributes unavailable.' });
+      });
+    });
+
+    it('returns an object of all attributes by default', () => {
+      const expected = {
+        waiting: 1,
+        active: 10,
+        completed: 100,
+        failed: 5,
+        delayed: 1,
+      };
+
+      const queueClient = new QueueClient(
+        mockQueue({}, expected)
+      );
+
+      return queueClient.getQueueAttributes().then((response) => {
+        expect(response).to.deep.equal(expected);
+      });
+    });
+
+    it('returns an object subset all requested attributes', () => {
+      const requestedAttributes = ['waiting', 'active'];
+      const allAttributes = {
+        waiting: 1,
+        active: 10,
+        completed: 100,
+        failed: 5,
+        delayed: 1,
+      };
+
+      const expected = {
+        waiting: 1,
+        active: 10,
+      };
+
+      const queueClient = new QueueClient(
+        mockQueue({}, allAttributes)
+      );
+
+      return queueClient.getQueueAttributes(requestedAttributes).then((response) => {
+        expect(response).to.deep.equal(expected);
+      });
+    });
+
+    it('returns an object subset available requested attributes', () => {
+      const requestedAttributes = ['waiting', 'active', 'not-an-attribute'];
+      const allAttributes = {
+        waiting: 1,
+        active: 10,
+        completed: 100,
+        failed: 5,
+        delayed: 1,
+      };
+
+      const expected = {
+        waiting: 1,
+        active: 10,
+      };
+
+      const queueClient = new QueueClient(
+        mockQueue({}, allAttributes)
+      );
+
+      return queueClient.getQueueAttributes(requestedAttributes).then((response) => {
+        expect(response).to.deep.equal(expected);
+      });
+    });
+
+    it('returns an object when preloading the queue', () => {
+      const queueName = 'queue-attributes';
+      const jobCountKeys = [
+        'active',
+        'completed',
+        'delayed',
+        'failed',
+        'paused',
+        'waiting',
+      ];
+      const jobData = [{
+        data: { test: 'a job', job_id: 1 },
+      }, {
+        data: { test: 'another job', job_id: 2 },
+      }, {
+        data: { test: 'another job again', job_id: 3 },
+      }];
+
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+
+        return queueClient.getQueueAttributes().then((response) => {
+          expect(response).to.have.keys(jobCountKeys);
+          expect(response.waiting).to.equal(jobData.length);
+        });
+      };
+
+      return addJobsToQueue(queueName, jobData, testMethod);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,6 +817,22 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+bull@^3.20.1:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/bull/-/bull-3.20.1.tgz#97c4156f48001565baf3c04b81267a5604f40754"
+  integrity sha512-wDwpVu47WKaGhiguEPa/US5UMrtGLPKNPiGFPo4OgVs3EEGzJEWwv3LRPfjJVIf1COdMAN/yowGhZwYmoOonjQ==
+  dependencies:
+    cron-parser "^2.13.0"
+    debuglog "^1.0.0"
+    get-port "^5.1.1"
+    ioredis "^4.22.0"
+    lodash "^4.17.19"
+    p-timeout "^3.2.0"
+    promise.prototype.finally "^3.1.2"
+    semver "^7.3.2"
+    util.promisify "^1.0.1"
+    uuid "^8.3.0"
+
 caching-transform@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-4.0.0.tgz#00d297a4206d71e2163c39eaffa8157ac0651f0f"
@@ -834,6 +850,14 @@ call-bind@^1.0.0:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.0"
+
+call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -931,6 +955,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1026,6 +1055,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cron-parser@^2.13.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
+  integrity sha512-s4odpheTyydAbTBQepsqd2rNWGa2iV3cyo8g7zbI2QQYGLVsfbhmwukayS1XHppe02Oy1fg7mg6xoaraVJeEcg==
+  dependencies:
+    is-nan "^1.3.0"
+    moment-timezone "^0.5.31"
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1048,6 +1085,11 @@ debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debuglog@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
+  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1084,6 +1126,11 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+denque@^1.1.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
@@ -1163,6 +1210,23 @@ es-abstract@^1.17.0:
     string.prototype.trimleft "^2.1.1"
     string.prototype.trimright "^2.1.1"
 
+es-abstract@^1.17.0-next.0:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
+  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
 es-abstract@^1.17.0-next.1:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
@@ -1196,6 +1260,26 @@ es-abstract@^1.17.5:
     object.assign "^4.1.0"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.2:
+  version "1.18.0-next.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
+  integrity sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.1"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.3"
+    string.prototype.trimstart "^1.0.3"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -1512,6 +1596,13 @@ follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
@@ -1588,10 +1679,24 @@ get-intrinsic@^1.0.0:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
 glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.0"
@@ -1768,6 +1873,22 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ioredis@^4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.22.0.tgz#a2e18a29300ffb759670d7ed7023fcf6592031a2"
+  integrity sha512-mtC+jNFMPRxReWx0HodDbcwj34Gj5pK/P4+aE6Nh0pdqgtZKvxUh4z2lVtLjqnRIvMhKaBnIgMYFR8qH/xtttA==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1784,6 +1905,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-callable@^1.1.3, is-callable@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
@@ -1822,6 +1948,19 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-nan@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -1844,6 +1983,14 @@ is-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
   integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   dependencies:
+    has-symbols "^1.0.1"
+
+is-regex@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
+  integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
+  dependencies:
+    call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
 is-stream@^2.0.0:
@@ -2132,6 +2279,16 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -2282,6 +2439,18 @@ mocha@^8.2.1:
     yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
 
+moment-timezone@^0.5.31:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2418,12 +2587,17 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
+object-inspect@^1.8.0, object-inspect@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0, object.assign@^4.1.2:
+object.assign@^4.1.0, object.assign@^4.1.1, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -2441,6 +2615,15 @@ object.entries@^1.1.2:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
     has "^1.0.3"
+
+object.getownpropertydescriptors@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
+  integrity sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
 
 object.values@^1.1.1:
   version "1.1.1"
@@ -2477,6 +2660,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -2534,12 +2722,24 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-map@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-map@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
   integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -2675,6 +2875,15 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise.prototype.finally@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz#b8af89160c9c673cefe3b4c4435b53cfd0287067"
+  integrity sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.0"
+    function-bind "^1.1.1"
+
 propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
@@ -2767,6 +2976,23 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
 regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -2852,6 +3078,13 @@ semver@^7.2.1:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.2:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 serialize-javascript@5.0.1:
   version "5.0.1"
@@ -2969,6 +3202,11 @@ stack-trace@0.0.x:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
+
 "string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -3003,6 +3241,14 @@ string.prototype.trimend@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
+string.prototype.trimend@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
 string.prototype.trimleft@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
@@ -3026,6 +3272,14 @@ string.prototype.trimstart@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -3201,6 +3455,17 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+util.promisify@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.1.tgz#77832f57ced2c9478174149cae9b96e9918cd54b"
+  integrity sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    for-each "^0.3.3"
+    has-symbols "^1.0.1"
+    object.getownpropertydescriptors "^2.1.1"
+
 uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -3210,6 +3475,11 @@ uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
To move toward an internal queue system, adding bull queue and client to manage queue messages in support of transition from SQS to bull.

To Do:
- [x] Add client for bull queue
- [x] Add bull client to build scheduler
- [x] Update build class to support bull job messages