### PR TITLE
Change from job remove to moveToCompleted on deleteMessage

### DIFF
--- a/src/bull-queue.js
+++ b/src/bull-queue.js
@@ -13,11 +13,12 @@ const bullQueue = (
   } = {}
 ) => {
   const redisUrl = appEnv.redisUrl;
+  const updatedClient = createClient || 'client';
   const updatedRedis = { tls: appEnv.redisTls, ...redis };
   const updatedSettings = { drainDelay: 20, ...settings };
 
   return new Queue(queueName, redisUrl, {
-    createClient,
+    createClient: updatedClient,
     redis: updatedRedis,
     limiter,
     prefix,

--- a/src/queue-client.js
+++ b/src/queue-client.js
@@ -15,7 +15,7 @@ class QueueClient {
           throw new Error(error);
         }
 
-        return job.remove();
+        return job.moveToCompleted(`Job ${id} completed`, true, true);
       })
       .then(() => message);
   }

--- a/test/queue-client-test.js
+++ b/test/queue-client-test.js
@@ -87,7 +87,9 @@ describe('QueueClient', () => {
         return queueClient.deleteMessage(message)
           .then((response) => {
             expect(response).to.deep.equal(message);
-          });
+          })
+          .then(() => queue.getJobCounts())
+          .then(counts => expect(counts.completed).to.equal(1));
       };
 
       return testAddJobsToQueue(queueName, jobData, testMethod);


### PR DESCRIPTION
Switch to using the `moveToCompleted` job method within the `deleteMessage` method. This way we will be able to view completed job stats, delete older completed jobs based on the number we want to keep or a time delimited task to remove old completed jobs.