### PR TITLE
Remove slack-users from Concourse job notifications

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -122,7 +122,6 @@ jobs:
             text: |
               :x: FAILED: pages builder deployment on staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))
@@ -136,7 +135,6 @@ jobs:
             text: |
               :white_check_mark: SUCCESS: Successfully deployed pages builder on staging
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              ((slack-users))
             channel: ((slack-channel))
             username: ((slack-username))
             icon_url: ((slack-icon-url))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove inclusion of slack-users variable in Concourse Slack job status messages

## security considerations
None
