### PR TITLE
Add -production env_postfix to pages-production to match app name

### DIFF
--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -1,5 +1,5 @@
 env: production
-env_postfix: ''
+env_postfix: '-production'
 task_max_mem: 20
 instances: 1
 product: pages


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `-production` to `pages-production` vars `env-postfix` to match CF_APP name in deploy task of pipeline. 

## security considerations
None
